### PR TITLE
fix: gate tauri default features (wry)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ push-notifications = ["dep:zbus", "dep:tokio", "dep:uuid"]
 notify-rust = ["dep:notify-rust"]
 
 [dependencies]
-tauri = "2"
+tauri = { version = "2", default-features = false }
 serde = "1.0"
-serde_json = "1"
+serde_json = "1.0"
 serde_repr = "0.1"
 thiserror = "2"
 log = "0.4"


### PR DESCRIPTION
Don't pull tauri's default features (wry) unconditionally, so downstream crates opt into the webview backend they need without forcing wry on every consumer.