### PR TITLE
feat: overhaul push delivery (UnifiedPush + WebPush on Android, structured response, warm-path rendering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ await sendNotification({
 
 #### Interactive Notifications with Actions
 
+For provider-rendered iOS notifications, configure action types in the Tauri
+`plugins.notifications.actionTypes` config so categories are registered before
+APNs delivers a notification. The provider's `aps.category` must match `id`.
+
 ```typescript
 import {
   sendNotification,
@@ -284,8 +288,9 @@ await sendNotification({
 });
 
 // Listen for action events
-const unlisten = await onAction((notification) => {
-  console.log('Action performed on notification:', notification);
+const unlisten = await onAction(({ actionId, inputValue, notification }) => {
+  console.log('Action:', actionId, 'reply:', inputValue);
+  console.log('Routing metadata:', notification.extra);
 });
 
 // Stop listening

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,7 @@
 import java.util.Properties
 import java.io.FileInputStream
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
 plugins {
     id("com.android.library")
@@ -65,6 +66,12 @@ android {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force("org.jetbrains.kotlin:kotlin-stdlib:${getKotlinPluginVersion()}")
+    }
+}
+
 dependencies {
     implementation("androidx.core:core-ktx:1.17.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
@@ -73,6 +80,8 @@ dependencies {
 
     implementation(platform("com.google.firebase:firebase-bom:34.16.0"))
     implementation("com.google.firebase:firebase-messaging-ktx:24.1.2")
+    implementation("org.unifiedpush.android:connector:3.3.3")
+    implementation("org.unifiedpush.android:embedded-fcm-distributor:3.0.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("io.mockk:mockk-android:1.14.11")
     testImplementation("io.mockk:mockk-agent:1.14.11")

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <queries>
+        <intent>
+            <action android:name="org.unifiedpush.android.distributor.REGISTER" />
+        </intent>
+    </queries>
+
     <application>
         <receiver android:name="app.tauri.notification.TimedNotificationPublisher" android:exported="true" />
         <receiver android:name="app.tauri.notification.NotificationDismissReceiver" android:exported="false" />
@@ -22,6 +28,18 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <!-- UnifiedPush connector receiver -->
+        <receiver
+            android:name="app.tauri.notification.UnifiedPushReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="org.unifiedpush.android.connector.NEW_ENDPOINT" />
+                <action android:name="org.unifiedpush.android.connector.UNREGISTERED" />
+                <action android:name="org.unifiedpush.android.connector.MESSAGE" />
+                <action android:name="org.unifiedpush.android.connector.REGISTRATION_FAILED" />
+            </intent-filter>
+        </receiver>
     </application>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/android/src/main/java/app/tauri/notification/CachedKeyManager.kt
+++ b/android/src/main/java/app/tauri/notification/CachedKeyManager.kt
@@ -1,0 +1,55 @@
+package app.tauri.notification
+
+import android.content.Context
+import org.unifiedpush.android.connector.keys.DefaultKeyManager
+import org.unifiedpush.android.connector.keys.KeyManager
+import org.unifiedpush.android.connector.data.PublicKeySet
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Wraps DefaultKeyManager with in-memory caching to avoid repeated
+ * AndroidKeyStore access for getPublicKeySet/exists calls.
+ */
+class CachedKeyManager private constructor(context: Context) : KeyManager {
+    private val delegate = DefaultKeyManager(context)
+    private val pubkeyCache = ConcurrentHashMap<String, PublicKeySet>()
+    private val existsCache = ConcurrentHashMap<String, Boolean>()
+
+    override fun decrypt(instance: String, sealed: ByteArray): ByteArray? {
+        return delegate.decrypt(instance, sealed)
+    }
+
+    override fun generate(instance: String) {
+        pubkeyCache.remove(instance)
+        existsCache.remove(instance)
+        delegate.generate(instance)
+    }
+
+    override fun getPublicKeySet(instance: String): PublicKeySet? {
+        pubkeyCache[instance]?.let { return it }
+        val keys = delegate.getPublicKeySet(instance)
+        if (keys != null) pubkeyCache[instance] = keys
+        return keys
+    }
+
+    override fun exists(instance: String): Boolean {
+        return existsCache.getOrPut(instance) { delegate.exists(instance) }
+    }
+
+    override fun delete(instance: String) {
+        pubkeyCache.remove(instance)
+        existsCache.remove(instance)
+        delegate.delete(instance)
+    }
+
+    companion object {
+        @Volatile
+        private var instance: CachedKeyManager? = null
+
+        fun getInstance(context: Context): CachedKeyManager {
+            return instance ?: synchronized(this) {
+                instance ?: CachedKeyManager(context.applicationContext).also { instance = it }
+            }
+        }
+    }
+}

--- a/android/src/main/java/app/tauri/notification/NotificationPlugin.kt
+++ b/android/src/main/java/app/tauri/notification/NotificationPlugin.kt
@@ -7,6 +7,8 @@ import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.webkit.WebView
 import app.tauri.PermissionState
 import app.tauri.annotation.Command
@@ -20,14 +22,19 @@ import app.tauri.plugin.JSArray
 import app.tauri.plugin.JSObject
 import app.tauri.plugin.Plugin
 import com.google.firebase.messaging.FirebaseMessaging
+import org.unifiedpush.android.connector.UnifiedPush
+import java.util.ArrayDeque
 
 const val LOCAL_NOTIFICATIONS = "permissionState"
+private const val MAX_PENDING_ACTIONS = 32
+private const val PUSH_REGISTRATION_TIMEOUT_MS = 30_000L
 
 @InvokeArg
 class PluginConfig {
   var icon: String? = null
   var sound: String? = null
   var iconColor: String? = null
+  var actionTypes: List<ActionType>? = null
 }
 
 @InvokeArg
@@ -59,8 +66,24 @@ class RegisterActionTypesArgs {
 }
 
 @InvokeArg
+class RegisterPushArgs {
+  var vapid: String? = null
+  var provider: String? = null
+}
+
+@InvokeArg
 class SetClickListenerActiveArgs {
   var active: Boolean = false
+}
+
+@InvokeArg
+class SetActionListenerActiveArgs {
+  var active: Boolean = false
+}
+
+@InvokeArg
+class DistributorArgs {
+  var distributor: String? = null
 }
 
 @InvokeArg
@@ -86,12 +109,31 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
   private lateinit var notificationStorage: NotificationStorage
   private var channelManager = ChannelManager(activity)
 
-  private var pendingTokenInvoke: Invoke? = null
-  private var cachedToken: String? = null
+  private data class PushRegistration(
+    val vapid: String?,
+    val provider: String,
+    val instance: String?,
+    var distributor: String?,
+    var phase: PushRegistrationPhase,
+    val invoke: Invoke,
+    val generation: Long,
+    var timeout: Runnable? = null
+  )
+
+  private enum class PushRegistrationPhase { PERMISSION, DISTRIBUTOR, UNIFIED_PUSH, FCM }
+
+  private var pendingPushRegistration: PushRegistration? = null
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private var fcmToken: String? = null
+  private val unifiedPushState = UnifiedPushStateStore(activity)
+  private var unifiedPushGeneration = 0L
+
 
   // Click listener tracking for cold-start support
   private var hasClickedListener = false
   private var pendingNotificationClick: JSObject? = null
+  private var hasActionListener = false
+  private val pendingNotificationActions = ArrayDeque<JSObject>()
 
   // onNewIntent can fire before load() during a cold start triggered
   // by a notification tap (Android delivers the launch intent via
@@ -153,6 +195,7 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
     manager.createNotificationChannel()
     
     this.manager = manager
+    getConfig(PluginConfig::class.java)?.actionTypes?.let { notificationStorage.writeActionGroup(it) }
     
     notificationManager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
@@ -184,6 +227,16 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
     onIntent(intent)
   }
 
+  override fun onDestroy() {
+    pendingPushRegistration?.let { registration ->
+      if (registration.phase == PushRegistrationPhase.UNIFIED_PUSH ||
+        registration.phase == PushRegistrationPhase.DISTRIBUTOR) retireUnifiedPush(registration.instance)
+    }
+    finishPushRegistrationError("Notification plugin destroyed during push registration")
+    if (instance === this) instance = null
+    super.onDestroy()
+  }
+
   fun onIntent(intent: Intent) {
     Logger.debug(Logger.tags(TAG), "onIntent called - action: ${intent.action}, extras: ${intent.extras?.keySet()}")
 
@@ -191,11 +244,17 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
     if (Intent.ACTION_MAIN == intent.action) {
       val dataJson = manager.handleNotificationActionPerformed(intent, notificationStorage)
       if (dataJson != null) {
-        trigger("actionPerformed", dataJson)
-        triggerNotificationClicked(
-          intent.getIntExtra(NOTIFICATION_INTENT_KEY, -1),
-          extractLocalNotificationData(intent)
-        )
+        when (dataJson.getString("actionId")) {
+          DEFAULT_PRESS_ACTION -> {
+            triggerActionPerformed(dataJson)
+            triggerNotificationClicked(
+              intent.getIntExtra(NOTIFICATION_INTENT_KEY, -1),
+              extractLocalNotificationData(intent)
+            )
+          }
+          "dismiss" -> triggerActionPerformed(dataJson)
+          else -> triggerActionPerformed(dataJson)
+        }
         return
       }
     }
@@ -253,6 +312,15 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
     } else {
       Logger.debug(Logger.tags(TAG), "No click listener, storing as pending")
       pendingNotificationClick = clickedData
+    }
+  }
+
+  private fun triggerActionPerformed(data: JSObject) {
+    if (hasActionListener) {
+      trigger("actionPerformed", data)
+    } else {
+      if (pendingNotificationActions.size >= MAX_PENDING_ACTIONS) pendingNotificationActions.removeFirst()
+      pendingNotificationActions.add(data)
     }
   }
 
@@ -385,35 +453,143 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
       return
     }
 
+    val args = invoke.parseArgs(RegisterPushArgs::class.java)
+    val requestedVapid = args.vapid
+    val provider = args.provider ?: "auto"
+    if (provider !in setOf("auto", "fcm", "unifiedpush")) {
+      invoke.reject("Unknown push provider: $provider")
+      return
+    }
+    pendingPushRegistration?.let { registration ->
+      invoke.reject("Push registration already in progress")
+      return
+    }
+    if (provider == "fcm" && unifiedPushState.activeProvider == "unifiedpush") {
+      invoke.reject("Active UnifiedPush registration must be unregistered first")
+      return
+    }
+    if (provider == "unifiedpush" && unifiedPushState.activeProvider == "fcm") {
+      invoke.reject("Active FCM registration must be unregistered first")
+      return
+    }
+    val distributor = if (provider == "fcm") null else UnifiedPush.getSavedDistributor(activity)
+
+    // Reuse the current registration instead of re-registering.
+    if (provider != "fcm" &&
+      pendingPushRegistration == null &&
+      unifiedPushState.activeProvider == "unifiedpush" &&
+      distributor != null &&
+      distributor == unifiedPushState.distributor &&
+      requestedVapid == unifiedPushState.vapid &&
+      unifiedPushState.endpoint != null
+    ) {
+      val cached = JSObject()
+      cached.put("deviceToken", unifiedPushState.endpoint)
+      cached.put("instance", UnifiedPushStateStore.INSTANCE)
+      unifiedPushState.p256dh?.let { cached.put("p256dh", it) }
+      unifiedPushState.auth?.let { cached.put("auth", it) }
+      invoke.resolve(cached)
+      return
+    }
+
+    pendingPushRegistration = PushRegistration(
+      requestedVapid,
+      provider,
+      if (provider == "fcm") null else unifiedPushState.instanceForRegistration(),
+      distributor,
+      PushRegistrationPhase.PERMISSION,
+      invoke,
+      ++unifiedPushGeneration
+    )
+    schedulePushRegistrationTimeout()
+
     // First check if notifications are enabled
     if (!manager.areNotificationsEnabled()) {
       // Request permissions first
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         if (getPermissionState(LOCAL_NOTIFICATIONS) !== PermissionState.GRANTED) {
-          // Request permissions and then get token
-          pendingTokenInvoke = invoke
-          requestPermissionForAlias(LOCAL_NOTIFICATIONS, invoke, "pushPermissionsCallback")
+          try {
+            requestPermissionForAlias(LOCAL_NOTIFICATIONS, invoke, "pushPermissionsCallback")
+          } catch (error: Exception) {
+            finishPushRegistrationError(error.message ?: "Failed to request notification permissions")
+          }
           return
         }
       } else {
-        invoke.reject("Notification permissions not granted")
+        finishPushRegistrationError("Notification permissions not granted")
         return
       }
     }
 
-    // If we already have a cached token, return it immediately
-    cachedToken?.let {
-      val result = JSObject()
-      result.put("deviceToken", it)
-      invoke.resolve(result)
+    proceedPushRegistration()
+  }
+
+  private fun proceedPushRegistration() {
+    val registration = pendingPushRegistration ?: return
+    val webPushVapid = registration.vapid
+    // Re-read: the saved distributor may be gone, in which case register() sends
+    // no broadcast and we'd wait out the timeout. Fall through to selection.
+    val savedDistributor =
+      if (registration.provider == "fcm") null else UnifiedPush.getSavedDistributor(activity)
+    registration.distributor = savedDistributor
+    if (registration.provider != "fcm" && savedDistributor != null) {
+      registration.phase = PushRegistrationPhase.UNIFIED_PUSH
+      try {
+        UnifiedPush.register(activity, registration.instance!!, vapid = webPushVapid, keyManager = CachedKeyManager.getInstance(activity))
+      } catch (error: Exception) {
+        finishPushRegistrationError(error.message ?: "UnifiedPush registration failed")
+      }
       return
     }
 
-    // Store the invoke to respond later when we get the token
-    pendingTokenInvoke = invoke
+    if (webPushVapid != null && (registration.provider == "unifiedpush" || registration.provider == "auto")) {
+      registration.phase = PushRegistrationPhase.DISTRIBUTOR
+      try {
+        UnifiedPush.tryUseCurrentOrDefaultDistributor(activity) { success ->
+          if (pendingPushRegistration !== registration) return@tryUseCurrentOrDefaultDistributor
+          if (!success) {
+            finishPushRegistrationError("No UnifiedPush distributor available")
+            return@tryUseCurrentOrDefaultDistributor
+          }
+          try {
+            registration.distributor = UnifiedPush.getSavedDistributor(activity)
+            registration.phase = PushRegistrationPhase.UNIFIED_PUSH
+            UnifiedPush.register(activity, registration.instance!!, vapid = webPushVapid, keyManager = CachedKeyManager.getInstance(activity))
+          } catch (error: Exception) {
+            finishPushRegistrationError(error.message ?: "UnifiedPush registration failed")
+          }
+        }
+      } catch (error: Exception) {
+        finishPushRegistrationError(error.message ?: "UnifiedPush registration failed")
+      }
+      return
+    }
 
-    // Request the FCM token
-    getFirebaseToken()
+    if (registration.provider != "fcm" && UnifiedPush.getSavedDistributor(activity) != null) {
+      registration.phase = PushRegistrationPhase.UNIFIED_PUSH
+      try {
+        UnifiedPush.register(activity, registration.instance!!, keyManager = CachedKeyManager.getInstance(activity))
+      } catch (error: Exception) {
+        finishPushRegistrationError(error.message ?: "UnifiedPush registration failed")
+      }
+      return
+    }
+
+    if (registration.provider == "unifiedpush") {
+      finishPushRegistrationError("No UnifiedPush distributor available")
+      return
+    }
+
+    fcmToken?.let {
+      unifiedPushState.activeProvider = "fcm"
+      val result = JSObject()
+      result.put("deviceToken", it)
+      finishPushRegistrationSuccess(result)
+      return
+    }
+
+    registration.phase = PushRegistrationPhase.FCM
+    getFirebaseToken(registration)
   }
 
   @Command
@@ -423,52 +599,245 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
       return
     }
 
-    FirebaseMessaging.getInstance().deleteToken().addOnCompleteListener { task ->
-      if (!task.isSuccessful) {
-        invoke.reject("Failed to delete FCM token: ${task.exception?.message}")
-        return@addOnCompleteListener
+    val pendingUnifiedPush = pendingPushRegistration?.takeIf {
+      it.phase == PushRegistrationPhase.UNIFIED_PUSH || it.phase == PushRegistrationPhase.DISTRIBUTOR
+    }
+    val instanceToUnregister = pendingUnifiedPush?.instance ?: unifiedPushState.activeInstance ?: UnifiedPushStateStore.INSTANCE
+    finishPushRegistrationError("Push registration cancelled by unregister")
+
+    if (pendingUnifiedPush != null || unifiedPushState.activeProvider == "unifiedpush") {
+      try {
+        retireUnifiedPush(instanceToUnregister)
+      } catch (error: Exception) {
+        invoke.reject(error.message ?: "Failed to unregister UnifiedPush")
+        return
       }
-      cachedToken = null
+      unifiedPushState.activeProvider = null
+      invoke.resolve()
+      return
+    }
+
+    try {
+      FirebaseMessaging.getInstance().deleteToken().addOnCompleteListener { task ->
+        if (!task.isSuccessful) {
+          invoke.reject("Failed to delete FCM token: ${task.exception?.message}")
+          return@addOnCompleteListener
+        }
+        fcmToken = null
+        if (unifiedPushState.activeProvider == "fcm") unifiedPushState.activeProvider = null
+        invoke.resolve()
+      }
+    } catch (error: Exception) {
+      // No default FirebaseApp (embedded-FCM/VAPID, no google-services.json): nothing to delete.
+      fcmToken = null
+      if (unifiedPushState.activeProvider == "fcm") unifiedPushState.activeProvider = null
       invoke.resolve()
     }
   }
 
   @PermissionCallback
   private fun pushPermissionsCallback(invoke: Invoke) {
+    val registration = pendingPushRegistration
+    if (registration?.phase != PushRegistrationPhase.PERMISSION) {
+      return
+    }
     if (!manager.areNotificationsEnabled()) {
-      invoke.reject("Notification permissions denied")
-      pendingTokenInvoke = null
+      finishPushRegistrationError("Notification permissions denied")
       return
     }
 
-    // Permissions granted, now get the token
-    getFirebaseToken()
+    proceedPushRegistration()
   }
 
-  private fun getFirebaseToken() {
+  @Command
+  fun listDistributors(invoke: Invoke) {
+    val distributors = UnifiedPush.getDistributors(activity)
+    val result = JSObject()
+    val arr = JSArray()
+    distributors.forEach { arr.put(it) }
+    result.put("distributors", arr)
+    invoke.resolve(result)
+  }
+
+  @Command
+  fun setDistributor(invoke: Invoke) {
+    val args = invoke.parseArgs(DistributorArgs::class.java)
+    val distributor = args.distributor
+    if (distributor == null) {
+      invoke.reject("Distributor parameter is required")
+      return
+    }
+    if (pendingPushRegistration != null) {
+      // Cancel the in-flight registration so the switch isn't blocked.
+      finishPushRegistrationError("Superseded by distributor change")
+    }
+    val distributorChanged = UnifiedPush.getSavedDistributor(activity) != distributor
+    if (distributorChanged) {
+      // saveDistributor already replaces the previous primary. Unregistering
+      // here would also wipe it, since unregister() drops every distributor
+      // once the last instance is removed.
+      unifiedPushGeneration++
+      if (unifiedPushState.activeProvider == "unifiedpush") unifiedPushState.activeProvider = null
+      unifiedPushState.clearRegistration()
+    }
+    UnifiedPush.saveDistributor(activity, distributor)
+    if (distributorChanged) unifiedPushState.ensureExplicitInstance()
+    invoke.resolve()
+  }
+
+  @Command
+  fun setToken(invoke: Invoke) {
+    invoke.resolve()
+  }
+
+  fun onUnifiedPushNewEndpoint(endpoint: String, p256dh: String?, auth: String?, instance: String) {
+    val registration = pendingPushRegistration
+    if (registration?.phase != PushRegistrationPhase.UNIFIED_PUSH ||
+      registration.generation != unifiedPushGeneration || instance != registration.instance) {
+      // Endpoint rotated outside a registration: keep the cache fresh.
+      if (pendingPushRegistration == null &&
+        unifiedPushState.activeProvider == "unifiedpush" &&
+        instance == (unifiedPushState.activeInstance ?: UnifiedPushStateStore.INSTANCE)
+      ) {
+        unifiedPushState.endpoint = endpoint
+        unifiedPushState.p256dh = p256dh
+        unifiedPushState.auth = auth
+        unifiedPushState.distributor = UnifiedPush.getSavedDistributor(activity)
+        triggerUnifiedPushToken(endpoint, p256dh, auth, if (p256dh == null) "direct" else "webpush")
+      }
+      return
+    }
+    unifiedPushState.setUnifiedPushActive()
+    unifiedPushState.endpoint = endpoint
+    unifiedPushState.activeInstance = registration.instance
+    unifiedPushState.p256dh = p256dh
+    unifiedPushState.auth = auth
+    unifiedPushState.distributor = registration.distributor ?: UnifiedPush.getSavedDistributor(activity)
+    unifiedPushState.vapid = registration.vapid
+    val result = JSObject()
+    result.put("deviceToken", endpoint)
+    result.put("instance", UnifiedPushStateStore.INSTANCE)
+    p256dh?.let { result.put("p256dh", it) }
+    auth?.let { result.put("auth", it) }
+    finishPushRegistrationSuccess(result)
+
+    triggerUnifiedPushToken(endpoint, p256dh, auth, if (registration.vapid == null) "direct" else "webpush")
+  }
+
+  fun onUnifiedPushRegistrationFailed(reason: String?, instance: String) {
+    val registration = pendingPushRegistration
+    if (registration?.phase != PushRegistrationPhase.UNIFIED_PUSH ||
+      registration.generation != unifiedPushGeneration || instance != registration.instance) return
+    finishPushRegistrationError(reason ?: "UnifiedPush registration failed")
+  }
+
+  fun onUnifiedPushUnregistered(instance: String) {
+  }
+
+  fun onUnifiedPushTemporaryUnavailable(instance: String) {
+    // Temporary distributor loss is nonterminal; endpoint/failure/timeout settles registration.
+  }
+
+  fun onNotificationDismissed(id: Int) {
+    val notification = JSObject()
+    notification.put("id", id)
+    val action = JSObject()
+    action.put("actionId", "dismiss")
+    action.put("notification", notification)
+    triggerActionPerformed(action)
+  }
+
+  fun onUnifiedPushMessage(content: String, instance: String) {
+    if (instance != unifiedPushState.activeInstance || unifiedPushState.activeProvider != "unifiedpush") return
+    val data = JSObject()
+    data.put("message", content)
+    data.put("transport", "unifiedpush")
+    data.put("instance", "default")
+    trigger("push-message", data)
+  }
+
+  private fun triggerUnifiedPushToken(endpoint: String, p256dh: String?, auth: String?, mode: String) {
+    val data = JSObject()
+    data.put("token", endpoint)
+    data.put("provider", "unifiedpush")
+    data.put("instance", UnifiedPushStateStore.INSTANCE)
+    data.put("mode", mode)
+    p256dh?.let { data.put("p256dh", it) }
+    auth?.let { data.put("auth", it) }
+    trigger("push-token", data)
+  }
+
+  private fun getFirebaseToken(registration: PushRegistration) {
     if (!BuildConfig.ENABLE_PUSH_NOTIFICATIONS) {
-      pendingTokenInvoke?.reject("Push notifications are disabled in this build")
-      pendingTokenInvoke = null
+      finishPushRegistrationError("Push notifications are disabled in this build")
       return
     }
 
-    FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
-      if (!task.isSuccessful) {
-        val errorMessage = "Failed to get FCM token: ${task.exception?.message}"
-        val errorData = JSObject()
-        errorData.put("message", errorMessage)
-        trigger("push-error", errorData)
-        pendingTokenInvoke?.reject(errorMessage)
-        pendingTokenInvoke = null
-        return@addOnCompleteListener
-      }
+    try {
+      FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+        if (pendingPushRegistration !== registration || registration.phase != PushRegistrationPhase.FCM) {
+          return@addOnCompleteListener
+        }
+        if (!task.isSuccessful) {
+          val errorMessage = "Failed to get FCM token: ${task.exception?.message}"
+          val errorData = JSObject()
+          errorData.put("message", errorMessage)
+          trigger("push-error", errorData)
+          finishPushRegistrationError(errorMessage)
+          return@addOnCompleteListener
+        }
 
-      val token = task.result
-      cachedToken = token
-      val result = JSObject()
-      result.put("deviceToken", token)
-      pendingTokenInvoke?.resolve(result)
-      pendingTokenInvoke = null
+        val token = task.result
+        fcmToken = token
+        unifiedPushState.activeProvider = "fcm"
+        val result = JSObject()
+        result.put("deviceToken", token)
+        finishPushRegistrationSuccess(result)
+      }
+    } catch (error: Exception) {
+      finishPushRegistrationError(error.message ?: "Failed to get FCM token")
+    }
+  }
+
+  private fun finishPushRegistrationSuccess(result: JSObject) {
+    val registration = pendingPushRegistration ?: return
+    pendingPushRegistration = null
+    registration.timeout?.let { mainHandler.removeCallbacks(it) }
+    registration.invoke.resolve(result)
+  }
+
+  private fun finishPushRegistrationError(message: String) {
+    val registration = pendingPushRegistration ?: return
+    pendingPushRegistration = null
+    registration.timeout?.let { mainHandler.removeCallbacks(it) }
+    registration.invoke.reject(message)
+  }
+
+  private fun schedulePushRegistrationTimeout() {
+    val registration = pendingPushRegistration ?: return
+    val timeout = Runnable {
+      if (pendingPushRegistration === registration) {
+        if (registration.phase == PushRegistrationPhase.UNIFIED_PUSH || registration.phase == PushRegistrationPhase.DISTRIBUTOR) {
+          retireUnifiedPush(registration.instance)
+        }
+        finishPushRegistrationError("Timed out registering for push notifications")
+      }
+    }
+    registration.timeout = timeout
+    mainHandler.postDelayed(timeout, PUSH_REGISTRATION_TIMEOUT_MS)
+  }
+
+  private fun retireUnifiedPush(instance: String?) {
+    unifiedPushGeneration++
+    try { UnifiedPush.unregister(activity, instance ?: UnifiedPushStateStore.INSTANCE, CachedKeyManager.getInstance(activity)) } catch (_: Exception) {
+    }
+    val activeInstance = unifiedPushState.activeInstance
+    val retiresActiveInstance = activeInstance == instance ||
+      (activeInstance == null && instance == UnifiedPushStateStore.INSTANCE &&
+        unifiedPushState.activeProvider == "unifiedpush")
+    if (retiresActiveInstance) {
+      if (unifiedPushState.activeProvider == "unifiedpush") unifiedPushState.activeProvider = null
+      unifiedPushState.clearRegistration()
     }
   }
 
@@ -476,7 +845,8 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
   fun handleNewToken(token: String) {
     if (!BuildConfig.ENABLE_PUSH_NOTIFICATIONS) return
 
-    cachedToken = token
+    if (unifiedPushState.activeProvider != "fcm") return
+    fcmToken = token
     // Trigger push-token event to notify the frontend about the token
     val data = JSObject()
     data.put("token", token)
@@ -486,6 +856,7 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
   // Called by TauriFirebaseMessagingService when a push message is received
   fun triggerPushMessage(pushData: Map<String, Any>) {
     if (!BuildConfig.ENABLE_PUSH_NOTIFICATIONS) return
+    if (unifiedPushState.activeProvider != "fcm") return
 
     val data = JSObject()
     for ((key, value) in pushData) {
@@ -541,6 +912,20 @@ class NotificationPlugin(private val activity: Activity): Plugin(activity) {
     if (args.active && pendingNotificationClick != null) {
       trigger("notificationClicked", pendingNotificationClick!!)
       pendingNotificationClick = null
+    }
+
+    invoke.resolve()
+  }
+
+  @Command
+  fun setActionListenerActive(invoke: Invoke) {
+    val args = invoke.parseArgs(SetActionListenerActiveArgs::class.java)
+    hasActionListener = args.active
+
+    if (args.active) {
+      while (pendingNotificationActions.isNotEmpty()) {
+        trigger("actionPerformed", pendingNotificationActions.removeFirst())
+      }
     }
 
     invoke.resolve()

--- a/android/src/main/java/app/tauri/notification/TauriFirebaseMessagingService.kt
+++ b/android/src/main/java/app/tauri/notification/TauriFirebaseMessagingService.kt
@@ -1,24 +1,21 @@
 package app.tauri.notification
 
-import app.tauri.plugin.JSObject
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import org.json.JSONObject
 
 class TauriFirebaseMessagingService : FirebaseMessagingService() {
 
   override fun onNewToken(token: String) {
     super.onNewToken(token)
-    // Store the token for later retrieval and trigger push-token event
     NotificationPlugin.instance?.handleNewToken(token)
   }
 
   override fun onMessageReceived(message: RemoteMessage) {
     super.onMessageReceived(message)
 
-    // Build push message data from RemoteMessage
     val pushData = mutableMapOf<String, Any>()
 
-    // Add notification data if present
     message.notification?.let { notification ->
       notification.title?.let { pushData["title"] = it }
       notification.body?.let { pushData["body"] = it }
@@ -27,41 +24,19 @@ class TauriFirebaseMessagingService : FirebaseMessagingService() {
       notification.tag?.let { pushData["tag"] = it }
     }
 
-    // Add data payload
     if (message.data.isNotEmpty()) {
       pushData["data"] = message.data
     }
 
-    // Add message metadata
     message.messageId?.let { pushData["messageId"] = it }
     message.from?.let { pushData["from"] = it }
     pushData["sentTime"] = message.sentTime
 
-    // Trigger push-message event
-    NotificationPlugin.instance?.triggerPushMessage(pushData)
-
-    // Also auto-show notification if notification payload exists
-    val notification = message.notification
-    if (notification != null) {
-      val notificationData = Notification().apply {
-        id = System.currentTimeMillis().toInt()
-        title = notification.title ?: ""
-        body = notification.body
-        channelId = notification.channelId
-        sound = notification.sound
-
-        // Add data payload if available
-        if (message.data.isNotEmpty()) {
-          val extraData = JSObject()
-          for ((key, value) in message.data) {
-            extraData.put(key, value)
-          }
-          extra = extraData
-        }
-      }
-
-      // Trigger notification event for push notification received in foreground
-      NotificationPlugin.triggerNotification(notificationData, "push")
+    if (message.data.isNotEmpty() && UnifiedPushStateStore(this).activeProvider == "fcm") {
+      val dataJson = JSONObject(message.data as Map<String, Any>)
+      UnifiedPushNotifier.showFromPush(this, dataJson.toString())
     }
+
+    NotificationPlugin.instance?.triggerPushMessage(pushData)
   }
 }

--- a/android/src/main/java/app/tauri/notification/TauriNotificationManager.kt
+++ b/android/src/main/java/app/tauri/notification/TauriNotificationManager.kt
@@ -291,7 +291,8 @@ class TauriNotificationManager(
       Intent(context, activity.javaClass)
     } else {
       val packageName = context.packageName
-      context.packageManager.getLaunchIntentForPackage(packageName)!!
+      context.packageManager.getLaunchIntentForPackage(packageName)
+        ?: Intent(Intent.ACTION_MAIN).setPackage(packageName)
     }
     intent.action = Intent.ACTION_MAIN
     intent.addCategory(Intent.CATEGORY_LAUNCHER)
@@ -466,6 +467,7 @@ class NotificationDismissReceiver : BroadcastReceiver() {
       val notificationStorage = NotificationStorage(context, ObjectMapper())
       notificationStorage.deleteNotification(intExtra.toString())
     }
+    NotificationPlugin.instance?.onNotificationDismissed(intExtra)
   }
 }
 

--- a/android/src/main/java/app/tauri/notification/UnifiedPushNotifier.kt
+++ b/android/src/main/java/app/tauri/notification/UnifiedPushNotifier.kt
@@ -1,0 +1,170 @@
+package app.tauri.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.RemoteInput
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.json.JSONObject
+
+object UnifiedPushNotifier {
+    private const val CHANNEL_ID = "messages"
+    private const val ACTION_TYPE_ID = "sable-message"
+    private const val GROUP_KEY = "matrix_messages"
+
+    fun showFromPush(context: Context, rawMessage: String) {
+        val rootJson = try {
+            JSONObject(rawMessage)
+        } catch (e: Exception) {
+            null
+        } ?: return
+
+        // Also accept the payload nested as a JSON string, not just an object.
+        val notification = rootJson.optJSONObject("notification")
+            ?: rootJson.optString("notification").takeIf { it.isNotEmpty() }?.let {
+                try { JSONObject(it) } catch (e: Exception) { null }
+            }
+            ?: return
+
+        val roomId = notification.optString("room_id")
+        val eventId = notification.optString("event_id")
+        val sender = notification.optString("sender_display_name")
+        val title = notification.optString("room_name").ifEmpty {
+            notification.optString("sender_display_name").ifEmpty { "New message" }
+        }
+        val body = buildBody(notification, sender)
+
+        val userId = rootJson.optString("user_id").ifEmpty {
+            notification.optString("user_id")
+        }
+
+        ensureChannel(context)
+
+        val iconId = context.resources
+            .getIdentifier("notification_icon", "drawable", context.packageName)
+            .takeIf { it != 0 } ?: android.R.drawable.ic_dialog_info
+
+        val notifId = sableNotifId(userId, roomId)
+
+        val intent = buildPushIntent(context, notifId, roomId, eventId, userId)
+
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE
+        } else {
+            PendingIntent.FLAG_CANCEL_CURRENT
+        }
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(iconId)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setGroup(GROUP_KEY)
+            .setContentIntent(
+                PendingIntent.getActivity(context, notifId, intent, flags)
+            )
+
+        addReplyAction(context, builder, notifId, roomId, eventId, userId, flags)
+
+        NotificationManagerCompat.from(context).notify(notifId, builder.build())
+    }
+
+    private fun addReplyAction(
+        context: Context,
+        builder: NotificationCompat.Builder,
+        notifId: Int,
+        roomId: String,
+        eventId: String,
+        userId: String,
+        flags: Int
+    ) {
+        val storage = NotificationStorage(context, ObjectMapper())
+        val actions = storage.getActionGroup(ACTION_TYPE_ID)
+        for (action in actions) {
+            if (action == null) continue
+            val actionIntent = buildPushIntent(context, notifId, roomId, eventId, userId, action.id)
+            val actionPendingIntent = PendingIntent.getActivity(
+                context, notifId + action.id.hashCode(), actionIntent, flags
+            )
+            val actionBuilder = NotificationCompat.Action.Builder(
+                R.drawable.ic_transparent, action.title, actionPendingIntent
+            )
+            if (action.input == true) {
+                actionBuilder.addRemoteInput(
+                    RemoteInput.Builder(REMOTE_INPUT_KEY).setLabel(action.title).build()
+                )
+            }
+            builder.addAction(actionBuilder.build())
+        }
+    }
+
+    private fun sableNotifId(userId: String, roomId: String): Int {
+        val key = "$userId\u0000$roomId"
+        var hash = 0
+        for (element in key) {
+            hash = 31 * hash + element.code
+        }
+        return Math.abs(hash)
+    }
+
+    private fun buildPushIntent(
+        context: Context,
+        notifId: Int,
+        roomId: String,
+        eventId: String,
+        userId: String,
+        action: String = DEFAULT_PRESS_ACTION
+    ): Intent {
+        val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+            ?: Intent(Intent.ACTION_MAIN).setPackage(context.packageName)
+        intent.action = Intent.ACTION_MAIN
+        intent.addCategory(Intent.CATEGORY_LAUNCHER)
+        intent.flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        intent.putExtra(NOTIFICATION_INTENT_KEY, notifId)
+        intent.putExtra(ACTION_INTENT_KEY, action)
+        intent.putExtra(NOTIFICATION_IS_REMOVABLE_KEY, true)
+
+        val extraJson = JSONObject().apply {
+            put("room_id", roomId)
+            put("event_id", eventId)
+            if (userId.isNotEmpty()) put("user_id", userId)
+            put("instance", UnifiedPushStateStore.INSTANCE)
+        }
+        val sourceJson = JSONObject().apply {
+            put("id", notifId)
+            put("extra", extraJson)
+            put("actionTypeId", ACTION_TYPE_ID)
+        }.toString()
+        intent.putExtra(NOTIFICATION_OBJ_INTENT_KEY, sourceJson)
+
+        return intent
+    }
+
+    private fun buildBody(notification: JSONObject, sender: String): String {
+        val prefix = if (sender.isNotEmpty()) "$sender: " else ""
+        if (notification.optString("type") == "m.room.encrypted") {
+            return "${prefix}Encrypted message"
+        }
+        val text = notification.optJSONObject("content")?.optString("body")?.takeIf { it.isNotEmpty() }
+        return if (text != null) "$prefix$text" else "${prefix}New message"
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(CHANNEL_ID, "Messages", NotificationManager.IMPORTANCE_HIGH).apply {
+                    description = "Matrix message and invite notifications"
+                }
+            )
+        }
+    }
+}

--- a/android/src/main/java/app/tauri/notification/UnifiedPushReceiver.kt
+++ b/android/src/main/java/app/tauri/notification/UnifiedPushReceiver.kt
@@ -1,0 +1,52 @@
+package app.tauri.notification
+
+import android.content.Context
+import org.unifiedpush.android.connector.FailedReason
+import org.unifiedpush.android.connector.MessagingReceiver
+import org.unifiedpush.android.connector.UnifiedPush
+import org.unifiedpush.android.connector.data.PushEndpoint
+import org.unifiedpush.android.connector.data.PushMessage
+import org.unifiedpush.android.connector.keys.KeyManager
+
+class UnifiedPushReceiver : MessagingReceiver() {
+
+    override fun getKeyManager(context: Context): KeyManager {
+        return CachedKeyManager.getInstance(context)
+    }
+
+    override fun onNewEndpoint(context: Context, endpoint: PushEndpoint, instance: String) {
+        NotificationPlugin.instance?.onUnifiedPushNewEndpoint(
+            endpoint.url,
+            endpoint.pubKeySet?.pubKey,
+            endpoint.pubKeySet?.auth,
+            instance,
+        )
+    }
+
+    override fun onRegistrationFailed(context: Context, reason: FailedReason, instance: String) {
+        NotificationPlugin.instance?.onUnifiedPushRegistrationFailed(reason.name, instance)
+    }
+
+    override fun onUnregistered(context: Context, instance: String) {
+        NotificationPlugin.instance?.onUnifiedPushUnregistered(instance)
+    }
+
+    override fun onTempUnavailable(context: Context, instance: String) {
+        NotificationPlugin.instance?.onUnifiedPushTemporaryUnavailable(instance)
+    }
+
+    override fun onMessage(context: Context, message: PushMessage, instance: String) {
+        val content = String(message.content, Charsets.UTF_8)
+        val state = UnifiedPushStateStore(context)
+        if (instance != state.activeInstance || state.activeProvider != "unifiedpush") return
+        // Always show the native notification immediately from the push payload.
+        // This eliminates the JS round-trip delay on the warm path (app alive in
+        // background). JS still receives the push-message event for in-app badge
+        // updates and notification enrichment (inbox grouping, fetched content
+        // for event_id_only payloads). When JS calls sendNotification() with the
+        // same notification ID, Android UPDATES the existing notification rather
+        // than showing a duplicate.
+        UnifiedPushNotifier.showFromPush(context, content)
+        NotificationPlugin.instance?.onUnifiedPushMessage(content, instance)
+    }
+}

--- a/android/src/main/java/app/tauri/notification/UnifiedPushStateStore.kt
+++ b/android/src/main/java/app/tauri/notification/UnifiedPushStateStore.kt
@@ -1,0 +1,62 @@
+package app.tauri.notification
+
+import android.content.Context
+import org.unifiedpush.android.connector.UnifiedPush
+import java.util.UUID
+
+internal class UnifiedPushStateStore(private val context: Context) {
+  private val prefs = context.getSharedPreferences("tauri-notifications", Context.MODE_PRIVATE)
+
+  var activeProvider: String?
+    get() = prefs.getString("push-provider", null)?.takeUnless { it == "none" }
+      ?: if (!prefs.contains("push-provider") && UnifiedPush.getSavedDistributor(context) != null) "unifiedpush" else null
+    set(value) = prefs.edit().putString("push-provider", value ?: "none").apply()
+  var activeInstance: String?
+    get() = prefs.getString("push-instance", null)
+      ?: if (activeProvider == "unifiedpush") INSTANCE else null
+    set(value) = prefs.edit().putString("push-instance", value ?: INSTANCE).apply()
+  var endpoint: String?
+    get() = prefs.getString("up-endpoint", null)
+    set(value) = prefs.edit().putString("up-endpoint", value).apply()
+  var p256dh: String?
+    get() = prefs.getString("up-p256dh", null)
+    set(value) = prefs.edit().putString("up-p256dh", value).apply()
+  var auth: String?
+    get() = prefs.getString("up-auth", null)
+    set(value) = prefs.edit().putString("up-auth", value).apply()
+  var distributor: String?
+    get() = prefs.getString("up-distributor", null)
+    set(value) = prefs.edit().putString("up-distributor", value).apply()
+  var vapid: String?
+    get() = prefs.getString("up-vapid", null)
+    set(value) = prefs.edit().putString("up-vapid", value).apply()
+
+  fun clearRegistration() {
+    prefs.edit()
+      .remove("push-instance")
+      .remove("up-endpoint")
+      .remove("up-p256dh")
+      .remove("up-auth")
+      .remove("up-distributor")
+      .remove("up-vapid")
+      .apply()
+  }
+  fun instanceForRegistration(): String {
+    val current = activeInstance
+    if (current != null && current != INSTANCE) {
+      try { UnifiedPush.unregister(context, current, CachedKeyManager.getInstance(context)) } catch (_: Exception) {}
+      activeInstance = INSTANCE
+    }
+    return INSTANCE
+  }
+  fun ensureExplicitInstance() {
+    if (prefs.getString("push-instance", null) == null) {
+      activeInstance = INSTANCE
+    }
+  }
+  fun setUnifiedPushActive() { activeProvider = "unifiedpush" }
+
+  companion object {
+    const val INSTANCE = "default"
+  }
+}

--- a/android/src/test/java/app/tauri/notification/UnifiedPushStateStoreTest.kt
+++ b/android/src/test/java/app/tauri/notification/UnifiedPushStateStoreTest.kt
@@ -1,0 +1,58 @@
+package app.tauri.notification
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class UnifiedPushStateStoreTest {
+
+    private fun newStore() = UnifiedPushStateStore(RuntimeEnvironment.getApplication())
+
+    @Test
+    fun persistsRegistrationAcrossInstances() {
+        val store = newStore()
+        store.activeProvider = "unifiedpush"
+        store.endpoint = "https://ntfy.sh/upAbc?up=1"
+        store.p256dh = "pubkey"
+        store.auth = "authsecret"
+        store.distributor = "io.heckel.ntfy"
+        store.vapid = "vapidkey"
+
+        val reopened = newStore()
+        assertEquals("unifiedpush", reopened.activeProvider)
+        assertEquals("https://ntfy.sh/upAbc?up=1", reopened.endpoint)
+        assertEquals("pubkey", reopened.p256dh)
+        assertEquals("authsecret", reopened.auth)
+        assertEquals("io.heckel.ntfy", reopened.distributor)
+        assertEquals("vapidkey", reopened.vapid)
+    }
+
+    @Test
+    fun clearRegistrationDropsKeysButKeepsProvider() {
+        val store = newStore()
+        store.activeProvider = "unifiedpush"
+        store.endpoint = "https://ntfy.sh/upAbc?up=1"
+        store.p256dh = "pubkey"
+        store.auth = "authsecret"
+        store.distributor = "io.heckel.ntfy"
+        store.vapid = "vapidkey"
+
+        store.clearRegistration()
+
+        assertNull(store.endpoint)
+        assertNull(store.p256dh)
+        assertNull(store.auth)
+        assertNull(store.distributor)
+        assertNull(store.vapid)
+        assertEquals("unifiedpush", store.activeProvider)
+    }
+
+    @Test
+    fun activeProviderIsNullWhenUnset() {
+        assertNull(newStore().activeProvider)
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,7 @@ const COMMANDS: &[&str] = &[
     "create_channel",
     "permission_state",
     "set_click_listener_active",
+    "set_action_listener_active",
     "list_distributors",
     "set_distributor",
     "set_token",

--- a/examples/notifications-demo/src-tauri/gen/android/build.gradle.kts
+++ b/examples/notifications-demo/src-tauri/gen/android/build.gradle.kts
@@ -15,6 +15,11 @@ allprojects {
         google()
         mavenCentral()
     }
+    configurations.all {
+        resolutionStrategy {
+            force("org.jetbrains.kotlin:kotlin-stdlib:2.1.21")
+        }
+    }
 }
 
 tasks.register("clean").configure {

--- a/guest-js/index.test.ts
+++ b/guest-js/index.test.ts
@@ -474,16 +474,28 @@ describe("Notification Functions", () => {
   });
 
   describe("registerForPushNotifications", () => {
-    it("should call invoke and return push token", async () => {
-      const mockToken = "abc123token";
-      mockInvoke.mockResolvedValue(mockToken);
+    it("should call invoke and return the registration", async () => {
+      const registration = { deviceToken: "abc123token" };
+      mockInvoke.mockResolvedValue(registration);
 
-      const result = await registerForPushNotifications();
+      const result = await registerForPushNotifications("vapid-key");
 
       expect(mockInvoke).toHaveBeenCalledWith(
         "plugin:notifications|register_for_push_notifications",
+        { vapid: "vapid-key", provider: "auto" },
       );
-      expect(result).toBe(mockToken);
+      expect(result).toBe(registration);
+    });
+
+    it("should forward an explicit push provider", async () => {
+      mockInvoke.mockResolvedValue({ deviceToken: "token" });
+
+      await registerForPushNotifications("vapid-key", "unifiedpush");
+
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "plugin:notifications|register_for_push_notifications",
+        { vapid: "vapid-key", provider: "unifiedpush" },
+      );
     });
   });
 
@@ -909,7 +921,9 @@ describe("Notification Functions", () => {
 
       mockAddPluginListener.mockImplementation((_plugin, _event, cb) => {
         capturedCallback = cb;
-        return Promise.resolve(vi.fn());
+        return Promise.resolve({
+          unregister: vi.fn().mockResolvedValue(undefined),
+        });
       });
 
       const callback = vi.fn();
@@ -923,8 +937,9 @@ describe("Notification Functions", () => {
 
   describe("onAction", () => {
     it("should register action performed listener", async () => {
-      const mockUnlisten = vi.fn();
-      mockAddPluginListener.mockResolvedValue(mockUnlisten);
+      const mockUnregister = vi.fn().mockResolvedValue(undefined);
+      mockAddPluginListener.mockResolvedValue({ unregister: mockUnregister });
+      mockInvoke.mockResolvedValue(undefined);
 
       const callback = vi.fn();
       const unlisten = await onAction(callback);
@@ -934,24 +949,99 @@ describe("Notification Functions", () => {
         "actionPerformed",
         callback,
       );
-      expect(unlisten).toBe(mockUnlisten);
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "plugin:notifications|set_action_listener_active",
+        { active: true },
+      );
+      expect(unlisten).toHaveProperty("unregister");
+      await unlisten.unregister();
     });
 
     it("should call callback when action performed", async () => {
-      const mockNotification = { title: "Test", actionTypeId: "action-1" };
-      let capturedCallback: ((notification: any) => void) | undefined;
+      const mockAction = {
+        actionId: "reply",
+        inputValue: "Hello",
+        notification: {
+          id: 1,
+          actionTypeId: "message-actions",
+          extra: { room_id: "!room:example.org" },
+        },
+      };
+      let capturedCallback: ((action: any) => void) | undefined;
 
       mockAddPluginListener.mockImplementation((_plugin, _event, cb) => {
         capturedCallback = cb;
-        return Promise.resolve(vi.fn());
+        return Promise.resolve({
+          unregister: vi.fn().mockResolvedValue(undefined),
+        });
       });
 
       const callback = vi.fn();
-      await onAction(callback);
+      const listener = await onAction(callback);
 
-      capturedCallback?.(mockNotification);
+      capturedCallback?.(mockAction);
 
-      expect(callback).toHaveBeenCalledWith(mockNotification);
+      expect(callback).toHaveBeenCalledWith(mockAction);
+      await listener.unregister();
+    });
+
+    it("should notify native side before unregistering", async () => {
+      const mockUnregister = vi.fn().mockResolvedValue(undefined);
+      mockAddPluginListener.mockResolvedValue({ unregister: mockUnregister });
+      mockInvoke.mockResolvedValue(undefined);
+
+      const listener = await onAction(vi.fn());
+      mockInvoke.mockClear();
+      await listener.unregister();
+
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "plugin:notifications|set_action_listener_active",
+        { active: false },
+      );
+      expect(mockUnregister).toHaveBeenCalled();
+    });
+
+    it("activates once for multiple listeners and deactivates after the last one", async () => {
+      const firstUnregister = vi.fn().mockResolvedValue(undefined);
+      const secondUnregister = vi.fn().mockResolvedValue(undefined);
+      mockAddPluginListener
+        .mockResolvedValueOnce({ unregister: firstUnregister })
+        .mockResolvedValueOnce({ unregister: secondUnregister });
+      mockInvoke.mockResolvedValue(undefined);
+
+      const first = await onAction(vi.fn());
+      const second = await onAction(vi.fn());
+      expect(mockInvoke).toHaveBeenCalledTimes(1);
+      await first.unregister();
+      expect(mockInvoke).toHaveBeenCalledTimes(1);
+      await second.unregister();
+      expect(mockInvoke).toHaveBeenCalledTimes(2);
+    });
+
+    it("rolls back the JS listener when activation fails", async () => {
+      const unregister = vi.fn().mockResolvedValue(undefined);
+      mockAddPluginListener.mockResolvedValue({ unregister });
+      mockInvoke.mockRejectedValueOnce(new Error("activation failed"));
+
+      await expect(onAction(vi.fn())).rejects.toThrow("activation failed");
+      expect(unregister).toHaveBeenCalled();
+    });
+
+    it("keeps the final JS listener and allows cleanup retry when deactivation fails", async () => {
+      const unregister = vi.fn().mockResolvedValue(undefined);
+      mockAddPluginListener.mockResolvedValue({ unregister });
+      mockInvoke
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("deactivation failed"))
+        .mockResolvedValueOnce(undefined);
+
+      const listener = await onAction(vi.fn());
+      await expect(listener.unregister()).rejects.toThrow(
+        "deactivation failed",
+      );
+      expect(unregister).not.toHaveBeenCalled();
+      await listener.unregister();
+      expect(unregister).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -359,6 +359,27 @@ interface ActiveNotification {
   sound?: string;
 }
 
+/** Data received when an action is performed on a notification. */
+interface ActionPerformedData {
+  /** Identifier of the selected action, or `tap`/`dismiss` for system actions. */
+  actionId: string;
+  /** Text entered for an action with `input: true`. */
+  inputValue?: string;
+  /** The notification, including its action type and extra metadata. */
+  notification: ActionNotification;
+}
+
+/** Notification data included with an action result. Platform-specific fields are optional. */
+interface ActionNotification {
+  /** Numeric local notification ID, or -1 when a provider notification has no numeric ID. */
+  id: number;
+  title?: string;
+  body?: string;
+  actionTypeId?: string;
+  extra?: Record<string, unknown>;
+  source?: "local" | "push";
+}
+
 /**
  * The importance level of a notification channel (Android).
  */
@@ -441,34 +462,32 @@ async function requestPermission(): Promise<NotificationPermission> {
   return await invoke("plugin:notifications|request_permission");
 }
 
+interface PushRegistration {
+  deviceToken: string;
+  p256dh?: string;
+  auth?: string;
+  instance?: string;
+}
+
+type PushProvider = "auto" | "fcm" | "unifiedpush";
+
 /**
  * Registers the app for push notifications.
  *
- * Returns a platform-dependent string identifying this push registration:
- * - **iOS**: APNs device token
- * - **Android**: Firebase Cloud Messaging token
- * - **Linux**: UnifiedPush endpoint URL (the URL your backend POSTs payloads to).
- *   The host app may persist this and treat it as the new endpoint on each
- *   launch (FCM/APNs style), or call {@link setToken} beforehand with a
- *   stored client token to receive the same endpoint URL across launches.
+ * `deviceToken` is the APNs token on iOS and the UnifiedPush endpoint URL on
+ * Android/Linux. Pass a base64url VAPID public key to register against a Web
+ * Push distributor; `p256dh` and `auth` are then set on the result.
  *
- * On Linux this requires the `push-notifications` feature and at least one
- * UnifiedPush distributor running on the system; see the README for setup.
- * Any {@link setDistributor} or {@link setToken} calls must happen
- * **before** this — they only affect the next register call, and once
- * registered the endpoint URL is fixed until you unregister.
- *
- * @example
- * ```typescript
- * import { registerForPushNotifications } from '@choochmeque/tauri-plugin-notifications-api';
- * const token = await registerForPushNotifications();
- * console.log('Push token:', token);
- * ```
- *
- * @returns A promise resolving to the platform-specific push identifier.
+ * @returns A promise resolving to the {@link PushRegistration}.
  */
-async function registerForPushNotifications(): Promise<string> {
-  return await invoke("plugin:notifications|register_for_push_notifications");
+async function registerForPushNotifications(
+  vapid?: string,
+  provider: PushProvider = "auto",
+): Promise<PushRegistration> {
+  return await invoke("plugin:notifications|register_for_push_notifications", {
+    vapid,
+    provider,
+  });
 }
 
 /**
@@ -818,13 +837,62 @@ async function onNotificationReceived(
  * // unlisten();
  * ```
  *
- * @param cb - Callback function to handle notification actions.
+ * @param cb - Callback function to handle notification action results.
  * @returns A promise resolving to a function that removes the listener.
  */
 async function onAction(
-  cb: (notification: Options) => void,
+  cb: (action: ActionPerformedData) => void,
 ): Promise<PluginListener> {
-  return await addPluginListener("notifications", "actionPerformed", cb);
+  const listener = await addPluginListener(
+    "notifications",
+    "actionPerformed",
+    cb,
+  );
+  try {
+    await withActionListenerLock(async () => {
+      if (actionListenerCount === 0) {
+        await invoke("plugin:notifications|set_action_listener_active", {
+          active: true,
+        });
+      }
+      actionListenerCount += 1;
+    });
+  } catch (error) {
+    await listener.unregister();
+    throw error;
+  }
+
+  let unregistered = false;
+  return {
+    unregister: async () => {
+      if (unregistered) return;
+      await withActionListenerLock(async () => {
+        if (actionListenerCount > 1) {
+          actionListenerCount -= 1;
+          return;
+        }
+        // Keep the final listener until native deactivation succeeds.
+        await invoke("plugin:notifications|set_action_listener_active", {
+          active: false,
+        });
+        actionListenerCount = 0;
+      });
+      unregistered = true;
+      await listener.unregister();
+    },
+  } as PluginListener;
+}
+
+let actionListenerCount = 0;
+let actionListenerLock = Promise.resolve();
+
+function withActionListenerLock<T>(operation: () => Promise<T>): Promise<T> {
+  const result = actionListenerLock.then(operation, operation);
+  actionListenerLock = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
 }
 
 /**
@@ -892,6 +960,10 @@ export type {
   Channel,
   ScheduleInterval,
   NotificationClickedData,
+  ActionPerformedData,
+  ActionNotification,
+  PushRegistration,
+  PushProvider,
 };
 
 export {

--- a/permissions/autogenerated/commands/set_action_listener_active.toml
+++ b/permissions/autogenerated/commands/set_action_listener_active.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-set-action-listener-active"
+description = "Enables the set_action_listener_active command without any pre-configured scope."
+commands.allow = ["set_action_listener_active"]
+
+[[permission]]
+identifier = "deny-set-action-listener-active"
+description = "Denies the set_action_listener_active command without any pre-configured scope."
+commands.deny = ["set_action_listener_active"]

--- a/permissions/autogenerated/reference.md
+++ b/permissions/autogenerated/reference.md
@@ -31,6 +31,7 @@ It allows all notification related features.
 - `allow-create-channel`
 - `allow-permission-state`
 - `allow-set-click-listener-active`
+- `allow-set-action-listener-active`
 - `allow-list-distributors`
 - `allow-set-distributor`
 - `allow-set-token`
@@ -560,6 +561,32 @@ Enables the request_permission command without any pre-configured scope.
 <td>
 
 Denies the request_permission command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`notifications:allow-set-action-listener-active`
+
+</td>
+<td>
+
+Enables the set_action_listener_active command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`notifications:deny-set-action-listener-active`
+
+</td>
+<td>
+
+Denies the set_action_listener_active command without any pre-configured scope.
 
 </td>
 </tr>

--- a/permissions/default.toml
+++ b/permissions/default.toml
@@ -33,6 +33,7 @@ permissions = [
   "allow-create-channel",
   "allow-permission-state",
   "allow-set-click-listener-active",
+  "allow-set-action-listener-active",
   "allow-list-distributors",
   "allow-set-distributor",
   "allow-set-token",

--- a/permissions/schemas/schema.json
+++ b/permissions/schemas/schema.json
@@ -535,6 +535,18 @@
           "markdownDescription": "Denies the request_permission command without any pre-configured scope."
         },
         {
+          "description": "Enables the set_action_listener_active command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-set-action-listener-active",
+          "markdownDescription": "Enables the set_action_listener_active command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_action_listener_active command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-set-action-listener-active",
+          "markdownDescription": "Denies the set_action_listener_active command without any pre-configured scope."
+        },
+        {
           "description": "Enables the set_click_listener_active command without any pre-configured scope.",
           "type": "string",
           "const": "allow-set-click-listener-active",
@@ -595,10 +607,10 @@
           "markdownDescription": "Denies the unregister_for_push_notifications command without any pre-configured scope."
         },
         {
-          "description": "This permission set configures which\nnotification features are by default exposed.\n\n#### Granted Permissions\n\nIt allows all notification related features.\n\n\n#### This default permission set includes:\n\n- `allow-is-permission-granted`\n- `allow-request-permission`\n- `allow-register-for-push-notifications`\n- `allow-unregister-for-push-notifications`\n- `allow-notify`\n- `allow-register-action-types`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-cancel`\n- `allow-cancel-all`\n- `allow-get-pending`\n- `allow-remove-active`\n- `allow-remove-all`\n- `allow-get-active`\n- `allow-check-permissions`\n- `allow-show`\n- `allow-batch`\n- `allow-list-channels`\n- `allow-delete-channel`\n- `allow-create-channel`\n- `allow-permission-state`\n- `allow-set-click-listener-active`\n- `allow-list-distributors`\n- `allow-set-distributor`\n- `allow-set-token`",
+          "description": "This permission set configures which\nnotification features are by default exposed.\n\n#### Granted Permissions\n\nIt allows all notification related features.\n\n\n#### This default permission set includes:\n\n- `allow-is-permission-granted`\n- `allow-request-permission`\n- `allow-register-for-push-notifications`\n- `allow-unregister-for-push-notifications`\n- `allow-notify`\n- `allow-register-action-types`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-cancel`\n- `allow-cancel-all`\n- `allow-get-pending`\n- `allow-remove-active`\n- `allow-remove-all`\n- `allow-get-active`\n- `allow-check-permissions`\n- `allow-show`\n- `allow-batch`\n- `allow-list-channels`\n- `allow-delete-channel`\n- `allow-create-channel`\n- `allow-permission-state`\n- `allow-set-click-listener-active`\n- `allow-set-action-listener-active`\n- `allow-list-distributors`\n- `allow-set-distributor`\n- `allow-set-token`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "This permission set configures which\nnotification features are by default exposed.\n\n#### Granted Permissions\n\nIt allows all notification related features.\n\n\n#### This default permission set includes:\n\n- `allow-is-permission-granted`\n- `allow-request-permission`\n- `allow-register-for-push-notifications`\n- `allow-unregister-for-push-notifications`\n- `allow-notify`\n- `allow-register-action-types`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-cancel`\n- `allow-cancel-all`\n- `allow-get-pending`\n- `allow-remove-active`\n- `allow-remove-all`\n- `allow-get-active`\n- `allow-check-permissions`\n- `allow-show`\n- `allow-batch`\n- `allow-list-channels`\n- `allow-delete-channel`\n- `allow-create-channel`\n- `allow-permission-state`\n- `allow-set-click-listener-active`\n- `allow-list-distributors`\n- `allow-set-distributor`\n- `allow-set-token`"
+          "markdownDescription": "This permission set configures which\nnotification features are by default exposed.\n\n#### Granted Permissions\n\nIt allows all notification related features.\n\n\n#### This default permission set includes:\n\n- `allow-is-permission-granted`\n- `allow-request-permission`\n- `allow-register-for-push-notifications`\n- `allow-unregister-for-push-notifications`\n- `allow-notify`\n- `allow-register-action-types`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-cancel`\n- `allow-cancel-all`\n- `allow-get-pending`\n- `allow-remove-active`\n- `allow-remove-all`\n- `allow-get-active`\n- `allow-check-permissions`\n- `allow-show`\n- `allow-batch`\n- `allow-list-channels`\n- `allow-delete-channel`\n- `allow-create-channel`\n- `allow-permission-state`\n- `allow-set-click-listener-active`\n- `allow-set-action-listener-active`\n- `allow-list-distributors`\n- `allow-set-distributor`\n- `allow-set-token`"
         }
       ]
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -40,8 +40,18 @@ pub async fn request_permission<R: Runtime>(
 pub async fn register_for_push_notifications<R: Runtime>(
     _app: AppHandle<R>,
     notification: State<'_, Notifications<R>>,
-) -> Result<String> {
-    notification.register_for_push_notifications().await
+    vapid: Option<String>,
+    provider: Option<String>,
+) -> Result<crate::models::PushNotificationResponse> {
+    #[cfg(mobile)]
+    return notification
+        .register_for_push_notifications(vapid, provider)
+        .await;
+    #[cfg(desktop)]
+    {
+        let _ = provider;
+        notification.register_for_push_notifications(vapid).await
+    }
 }
 
 #[command]
@@ -59,7 +69,10 @@ pub async fn unregister_for_push_notifications<R: Runtime>(
     }
 }
 
-#[cfg(all(desktop, target_os = "linux", feature = "push-notifications"))]
+#[cfg(all(
+    feature = "push-notifications",
+    any(all(desktop, target_os = "linux"), target_os = "android")
+))]
 #[command]
 pub async fn list_distributors<R: Runtime>(
     _app: AppHandle<R>,
@@ -68,7 +81,10 @@ pub async fn list_distributors<R: Runtime>(
     notification.list_distributors().await
 }
 
-#[cfg(all(desktop, target_os = "linux", feature = "push-notifications"))]
+#[cfg(all(
+    feature = "push-notifications",
+    any(all(desktop, target_os = "linux"), target_os = "android")
+))]
 #[command]
 pub async fn set_distributor<R: Runtime>(
     _app: AppHandle<R>,
@@ -78,7 +94,10 @@ pub async fn set_distributor<R: Runtime>(
     notification.set_distributor(name).await
 }
 
-#[cfg(all(desktop, target_os = "linux", feature = "push-notifications"))]
+#[cfg(all(
+    feature = "push-notifications",
+    any(all(desktop, target_os = "linux"), target_os = "android")
+))]
 #[command]
 pub async fn set_token<R: Runtime>(
     _app: AppHandle<R>,
@@ -131,6 +150,15 @@ pub fn set_click_listener_active<R: Runtime>(
     active: bool,
 ) -> Result<()> {
     notification.set_click_listener_active(active)
+}
+
+#[command]
+pub fn set_action_listener_active<R: Runtime>(
+    _app: AppHandle<R>,
+    notification: State<'_, Notifications<R>>,
+    active: bool,
+) -> Result<()> {
+    notification.set_action_listener_active(active)
 }
 
 #[command]

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -269,11 +269,18 @@ impl<R: Runtime> Notifications<R> {
     /// selected (or first available) `UnifiedPush` distributor and returns the
     /// endpoint URL. Apps that need endpoint stability across launches should
     /// call [`set_token`](Self::set_token) before this with a persisted token.
-    pub async fn register_for_push_notifications(&self) -> crate::Result<String> {
+    pub async fn register_for_push_notifications(
+        &self,
+        vapid: Option<String>,
+    ) -> crate::Result<crate::models::PushNotificationResponse> {
+        let _ = vapid;
         #[cfg(all(target_os = "linux", feature = "push-notifications"))]
         {
             let state = self.unifiedpush_state().await?;
-            state.register().await
+            let endpoint = state.register().await?;
+            Ok(crate::models::PushNotificationResponse::from_token(
+                endpoint,
+            ))
         }
         #[cfg(not(all(target_os = "linux", feature = "push-notifications")))]
         {
@@ -379,6 +386,10 @@ impl<R: Runtime> Notifications<R> {
         Err(crate::Error::Io(std::io::Error::other(
             "Click listeners are not supported with notify-rust",
         )))
+    }
+
+    pub const fn set_action_listener_active(&self, _active: bool) -> crate::Result<()> {
+        Ok(())
     }
 
     /// Linux: closes every tracked notification whose caller-supplied id

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,11 @@ use tauri::{
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct PluginConfig {
+    /// Notification action categories registered during native plugin startup.
+    /// This is required for provider-rendered iOS notifications whose
+    /// `aps.category` is received before JavaScript initializes.
+    #[serde(default)]
+    pub action_types: Vec<ActionType>,
     #[cfg(target_os = "windows")]
     pub windows: WindowsConfig,
 }
@@ -305,6 +310,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R, Option<PluginConfig>> {
             commands::get_pending,
             commands::get_active,
             commands::set_click_listener_active,
+            commands::set_action_listener_active,
             commands::remove_active,
             commands::remove_all,
             commands::cancel,
@@ -316,11 +322,20 @@ pub fn init<R: Runtime>() -> TauriPlugin<R, Option<PluginConfig>> {
             listeners::register_listener,
             #[cfg(desktop)]
             listeners::remove_listener,
-            #[cfg(all(desktop, target_os = "linux", feature = "push-notifications"))]
+            #[cfg(all(
+                feature = "push-notifications",
+                any(all(desktop, target_os = "linux"), target_os = "android")
+            ))]
             commands::list_distributors,
-            #[cfg(all(desktop, target_os = "linux", feature = "push-notifications"))]
+            #[cfg(all(
+                feature = "push-notifications",
+                any(all(desktop, target_os = "linux"), target_os = "android")
+            ))]
             commands::set_distributor,
-            #[cfg(all(desktop, target_os = "linux", feature = "push-notifications"))]
+            #[cfg(all(
+                feature = "push-notifications",
+                any(all(desktop, target_os = "linux"), target_os = "android")
+            ))]
             commands::set_token,
         ])
         .setup(|app, api| {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -191,14 +191,17 @@ impl<R: Runtime> Notifications<R> {
         Ok(response.permission_state)
     }
 
-    pub async fn register_for_push_notifications(&self) -> crate::Result<String> {
+    pub async fn register_for_push_notifications(
+        &self,
+        _vapid: Option<String>,
+    ) -> crate::Result<crate::PushNotificationResponse> {
         validation::require_bundle()?;
 
         #[cfg(feature = "push-notifications")]
         {
             let response: crate::PushNotificationResponse =
                 self.plugin.registerForPushNotifications().await.parse()?;
-            Ok(response.device_token)
+            Ok(response)
         }
         #[cfg(not(feature = "push-notifications"))]
         {
@@ -318,6 +321,10 @@ impl<R: Runtime> Notifications<R> {
                     .map_err(crate::error::PluginInvokeError::CannotSerializePayload)?,
             )
             .parse_void()
+    }
+
+    pub const fn set_action_listener_active(&self, _active: bool) -> crate::Result<()> {
+        Ok(())
     }
 
     /// Create a notification channel (not supported on macOS).

--- a/src/mobile.rs
+++ b/src/mobile.rs
@@ -4,10 +4,9 @@ use tauri::{
     plugin::{PermissionState, PluginApi, PluginHandle},
 };
 
-#[cfg(feature = "push-notifications")]
-use crate::models::PushNotificationResponse;
 use crate::models::{
     ActionType, ActiveNotification, Channel, PendingNotification, PermissionResponse,
+    PushNotificationResponse,
 };
 
 use std::collections::HashMap;
@@ -60,20 +59,32 @@ impl<R: Runtime> Notifications<R> {
             .map_err(Into::into)
     }
 
-    pub async fn register_for_push_notifications(&self) -> crate::Result<String> {
+    pub async fn register_for_push_notifications(
+        &self,
+        vapid: Option<String>,
+        provider: Option<String>,
+    ) -> crate::Result<PushNotificationResponse> {
         #[cfg(feature = "push-notifications")]
         {
+            #[derive(serde::Serialize)]
+            #[serde(rename_all = "camelCase")]
+            struct RegisterArgs {
+                #[serde(skip_serializing_if = "Option::is_none")]
+                vapid: Option<String>,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                provider: Option<String>,
+            }
             self.0
                 .run_mobile_plugin_async::<PushNotificationResponse>(
                     "registerForPushNotifications",
-                    (),
+                    RegisterArgs { vapid, provider },
                 )
                 .await
-                .map(|r| r.device_token)
                 .map_err(Into::into)
         }
         #[cfg(not(feature = "push-notifications"))]
         {
+            let _ = (vapid, provider);
             Err(crate::Error::Io(std::io::Error::other(
                 "Push notifications feature is not enabled",
             )))
@@ -93,6 +104,35 @@ impl<R: Runtime> Notifications<R> {
                 "Push notifications feature is not enabled",
             )))
         }
+    }
+
+    #[cfg(all(target_os = "android", feature = "push-notifications"))]
+    pub async fn list_distributors(&self) -> crate::Result<Vec<String>> {
+        self.0
+            .run_mobile_plugin_async::<crate::models::DistributorsResponse>("listDistributors", ())
+            .await
+            .map(|r| r.distributors)
+            .map_err(Into::into)
+    }
+
+    #[cfg(all(target_os = "android", feature = "push-notifications"))]
+    pub async fn set_distributor(&self, name: String) -> crate::Result<()> {
+        let mut args = HashMap::new();
+        args.insert("distributor", name);
+        self.0
+            .run_mobile_plugin_async::<()>("setDistributor", args)
+            .await
+            .map_err(Into::into)
+    }
+
+    #[cfg(all(target_os = "android", feature = "push-notifications"))]
+    pub async fn set_token(&self, token: String) -> crate::Result<()> {
+        let mut args = HashMap::new();
+        args.insert("token", token);
+        self.0
+            .run_mobile_plugin_async::<()>("setToken", args)
+            .await
+            .map_err(Into::into)
     }
 
     pub async fn permission_state(&self) -> crate::Result<PermissionState> {
@@ -211,6 +251,16 @@ impl<R: Runtime> Notifications<R> {
         args.insert("active", active);
         self.0
             .run_mobile_plugin("setClickListenerActive", args)
+            .map_err(Into::into)
+    }
+
+    /// Set action listener active state.
+    /// Used internally to queue action results until JS is ready.
+    pub fn set_action_listener_active(&self, active: bool) -> crate::Result<()> {
+        let mut args = HashMap::new();
+        args.insert("active", active);
+        self.0
+            .run_mobile_plugin("setActionListenerActive", args)
             .map_err(Into::into)
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -11,11 +11,34 @@ pub struct PermissionResponse {
     pub permission_state: PermissionState,
 }
 
-#[cfg(feature = "push-notifications")]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PushNotificationResponse {
     pub device_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub p256dh: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance: Option<String>,
+}
+
+impl PushNotificationResponse {
+    #[must_use]
+    pub const fn from_token(device_token: String) -> Self {
+        Self {
+            device_token,
+            p256dh: None,
+            auth: None,
+            instance: None,
+        }
+    }
+}
+
+#[cfg(all(target_os = "android", feature = "push-notifications"))]
+#[derive(Debug, Deserialize)]
+pub struct DistributorsResponse {
+    pub distributors: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -149,6 +149,7 @@ pub struct WindowsPlugin {
     notifier: ToastNotifier,
     action_types: RwLock<HashMap<String, ActionType>>,
     click_listener_active: RwLock<bool>,
+    action_listener_active: RwLock<bool>,
     /// Cold-start activation payloads queued before any JS listener has
     /// subscribed. Drained synchronously the first time a `notificationClicked`
     /// listener registers (see `crate::listeners::register_listener`).
@@ -349,6 +350,25 @@ impl WindowsPlugin {
         Ok(())
     }
 
+    fn is_action_listener_active(&self) -> crate::Result<bool> {
+        Ok(*self
+            .action_listener_active
+            .read()
+            .map_err(|_| crate::Error::Io(std::io::Error::other("Lock poisoned")))?)
+    }
+
+    fn set_action_listener(&self, active: bool) -> crate::Result<()> {
+        *self
+            .action_listener_active
+            .write()
+            .map_err(|_| crate::Error::Io(std::io::Error::other("Lock poisoned")))? = active;
+        Ok(())
+    }
+
+    fn is_activation_listener_active(&self) -> crate::Result<bool> {
+        Ok(self.is_click_listener_active()? || self.is_action_listener_active()?)
+    }
+
     /// Drain queued cold-start click payloads through the listener bus. Called
     /// when a `notificationClicked` listener subscribes (see
     /// `crate::listeners::register_listener`). Idempotent: subsequent calls
@@ -431,6 +451,7 @@ pub fn init<R: Runtime, C: DeserializeOwned>(
         notifier,
         action_types: RwLock::new(HashMap::new()),
         click_listener_active: RwLock::new(false),
+        action_listener_active: RwLock::new(false),
         pending_clicks: RwLock::new(Vec::new()),
         _com_cookie: RwLock::new(None),
         #[cfg(feature = "push-notifications")]
@@ -650,7 +671,7 @@ impl<R: Runtime> crate::NotificationsBuilder<R> {
                 toast.SetGroup(g)?;
             }
 
-            if self.plugin.is_click_listener_active()? {
+            if self.plugin.is_activation_listener_active()? {
                 let notification = ActiveNotification {
                     id: self.data.id,
                     tag: Some(self.data.id.to_string()),
@@ -825,8 +846,13 @@ impl<R: Runtime> Notifications<R> {
         self.permission_state().await
     }
 
-    pub async fn register_for_push_notifications(&self) -> crate::Result<String> {
-        self.plugin.open_push_channel()
+    pub async fn register_for_push_notifications(
+        &self,
+        _vapid: Option<String>,
+    ) -> crate::Result<PushNotificationResponse> {
+        self.plugin
+            .open_push_channel()
+            .map(PushNotificationResponse::from_token)
     }
 
     pub fn unregister_for_push_notifications(&self) -> crate::Result<()> {
@@ -855,13 +881,27 @@ impl<R: Runtime> Notifications<R> {
     pub fn remove_active(&self, notifications: Vec<i32>) -> crate::Result<()> {
         let history = ToastNotificationManager::History()?;
         let app_id = &self.plugin.app_id;
+
+        // Removal needs the same (tag, group) pair used at show time.
+        let delivered = if self.plugin.packaged {
+            history.GetHistory()?
+        } else {
+            history.GetHistoryWithId(&HSTRING::from(app_id))?
+        };
+        let mut groups: HashMap<String, HSTRING> = HashMap::new();
+        for i in 0..delivered.Size()? {
+            let notification = delivered.GetAt(i)?;
+            let tag = notification.Tag()?.to_string_lossy();
+            groups.insert(tag, notification.Group().unwrap_or_default());
+        }
+
         for id in notifications {
             let tag = HSTRING::from(id.to_string());
-            // Use app-scoped removal with empty group (consistent with GetHistoryWithId usage)
+            let group = groups.get(&id.to_string()).cloned().unwrap_or_default();
             let res = if self.plugin.packaged {
-                history.RemoveGroupedTag(&tag, &HSTRING::new())
+                history.RemoveGroupedTag(&tag, &group)
             } else {
-                history.RemoveGroupedTagWithId(&tag, &HSTRING::new(), &HSTRING::from(app_id))
+                history.RemoveGroupedTagWithId(&tag, &group, &HSTRING::from(app_id))
             };
             if let Err(e) = res {
                 log::error!("Failed to remove notification {id}: {e}");
@@ -1015,6 +1055,10 @@ impl<R: Runtime> Notifications<R> {
 
     pub fn set_click_listener_active(&self, active: bool) -> crate::Result<()> {
         self.plugin.set_click_listener(active)
+    }
+
+    pub fn set_action_listener_active(&self, active: bool) -> crate::Result<()> {
+        self.plugin.set_action_listener(active)
     }
 
     /// Create a notification channel (not supported on Windows).


### PR DESCRIPTION
Add a UnifiedPush backend alongside FCM on Android, with an embedded FCM WebPush distributor path. Registration now accepts an optional VAPID key and a provider selector ("auto" | "fcm" | "unifiedpush") and returns a structured PushNotificationResponse (deviceToken + p256dh/auth/instance for WebPush).

Android push payloads are rendered as native notifications on the warm path (BigTextStyle + reply actions) using a cached KeyManager, with queued action results delivered to JS via the new set_action_listener_active command and the rewritten onAction() listener.

- models: PushNotificationResponse gains p256dh/auth/instance; DistributorsResponse
- commands/mobile/desktop/macos/windows: new register signature + set_action_listener_active
- guest-js: PushRegistration/PushProvider types, onAction rewrite, ActionPerformedData
- permissions: set_action_listener_active (allow/deny), schema + reference + default
- android: UnifiedPushStateStore, UnifiedPushNotifier/Receiver, CachedKeyManager, NotificationPlugin dispatch, FCM warm-path, AndroidManifest, build.gradle deps
- build.rs: register set_action_listener_active command

The iOS setActionListenerActive handler lands in a follow-up PR.