### PR TITLE
feat(ios): chain push delegate callbacks, fix registration timeout, add action categories + action listener

### DIFF
--- a/ios/Sources/AppDelegateSwizzler.swift
+++ b/ios/Sources/AppDelegateSwizzler.swift
@@ -7,102 +7,111 @@ import ObjectiveC.runtime
 enum AppDelegateSwizzler {
   static weak var plugin: NotificationPlugin?
 
-  static func swizzlePushCallbacks() {
-    guard let app = UIApplication.shared as UIApplication?,
-          let delegate = app.delegate else { return }
+  private static var originalIMPs: [Selector: IMP] = [:]
+  private static var swizzled = false
 
-    // didRegisterForRemoteNotificationsWithDeviceToken
-    swizzle(
-      type(of: delegate),
+  static func swizzlePushCallbacks() {
+    guard !swizzled else { return }
+    guard let delegate = UIApplication.shared.delegate else { return }
+    swizzled = true
+    let cls: AnyClass = type(of: delegate)
+
+    install(
+      cls,
       #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)),
       #selector(PushForwarder.ta_application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
     )
-
-    // didFailToRegisterForRemoteNotificationsWithError
-    swizzle(
-      type(of: delegate),
+    install(
+      cls,
       #selector(UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:)),
       #selector(PushForwarder.ta_application(_:didFailToRegisterForRemoteNotificationsWithError:))
     )
-
-    // didReceiveRemoteNotification (silent/background)
-    swizzle(
-      type(of: delegate),
+    install(
+      cls,
       #selector(UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:)),
       #selector(PushForwarder.ta_application(_:didReceiveRemoteNotification:fetchCompletionHandler:))
     )
   }
 
-  private static func swizzle(_ cls: AnyClass, _ original: Selector, _ replacement: Selector) {
-    guard
-      let swizzledMethod = class_getInstanceMethod(PushForwarder.self, replacement)
-    else { return }
-
-    if let originalMethod = class_getInstanceMethod(cls, original) {
-      // Original method exists - exchange implementations
-      method_exchangeImplementations(originalMethod, swizzledMethod)
-    } else {
-      // Original method doesn't exist - add our method
-      class_addMethod(
-        cls,
-        original,
-        method_getImplementation(swizzledMethod),
-        method_getTypeEncoding(swizzledMethod)
-      )
+  /// Installs the forwarder, keeping the delegate's own implementation so it can still be chained.
+  private static func install(_ cls: AnyClass, _ selector: Selector, _ replacement: Selector) {
+    guard let replacementMethod = class_getInstanceMethod(PushForwarder.self, replacement) else { return }
+    let replacementIMP = method_getImplementation(replacementMethod)
+    let typeEncoding = method_getTypeEncoding(replacementMethod)
+    if let previousIMP = class_replaceMethod(cls, selector, replacementIMP, typeEncoding) {
+      originalIMPs[selector] = previousIMP
     }
+  }
+
+  fileprivate static func callOriginalDidRegister(
+    _ receiver: Any, _ selector: Selector, _ application: UIApplication, _ deviceToken: Data
+  ) {
+    guard let imp = originalIMPs[selector] else { return }
+    typealias Fn = @convention(c) (Any, Selector, UIApplication, Data) -> Void
+    unsafeBitCast(imp, to: Fn.self)(receiver, selector, application, deviceToken)
+  }
+
+  fileprivate static func callOriginalDidFail(
+    _ receiver: Any, _ selector: Selector, _ application: UIApplication, _ error: Error
+  ) {
+    guard let imp = originalIMPs[selector] else { return }
+    typealias Fn = @convention(c) (Any, Selector, UIApplication, Error) -> Void
+    unsafeBitCast(imp, to: Fn.self)(receiver, selector, application, error)
+  }
+
+  fileprivate static func callOriginalDidReceive(
+    _ receiver: Any, _ selector: Selector, _ application: UIApplication,
+    _ userInfo: [AnyHashable: Any], _ completion: @escaping (UIBackgroundFetchResult) -> Void
+  ) -> Bool {
+    guard let imp = originalIMPs[selector] else { return false }
+    typealias Fn = @convention(c) (Any, Selector, UIApplication, [AnyHashable: Any], @escaping (UIBackgroundFetchResult) -> Void) -> Void
+    unsafeBitCast(imp, to: Fn.self)(receiver, selector, application, userInfo, completion)
+    return true
   }
 }
 
-/// A helper that hosts the swizzled implementations.
-/// NOTE: These method names must exactly match the selectors we swizzle.
+/// Hosts the implementations installed onto the app delegate class. At call time
+/// `self` is the app delegate, so these may only touch params and static state.
 final class PushForwarder: NSObject, UIApplicationDelegate {
-  // Token success
   @objc func ta_application(_ application: UIApplication,
                             didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-    // Convert token to hex string
     let hex = deviceToken.map { String(format: "%02x", $0) }.joined()
-
-    // Notify plugin about token
     AppDelegateSwizzler.plugin?.handlePushTokenReceived(hex)
-
-    // Also emit event for JS/Rust listeners
     try? AppDelegateSwizzler.plugin?.trigger("push-token", data: ["token": hex])
-
-    // Call original only if it was swapped (not added)
-    if responds(to: #selector(ta_application(_:didRegisterForRemoteNotificationsWithDeviceToken:))) {
-      self.ta_application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
-    }
+    AppDelegateSwizzler.callOriginalDidRegister(
+      self,
+      #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)),
+      application,
+      deviceToken
+    )
   }
 
-  // Token failure
   @objc func ta_application(_ application: UIApplication,
                             didFailToRegisterForRemoteNotificationsWithError error: Error) {
-    // Notify plugin about error
     AppDelegateSwizzler.plugin?.handlePushTokenError(error)
-
-    // Also emit event for JS/Rust listeners
     try? AppDelegateSwizzler.plugin?.trigger("push-error", data: ["message": error.localizedDescription])
-
-    // Call original only if it was swapped (not added)
-    if responds(to: #selector(ta_application(_:didFailToRegisterForRemoteNotificationsWithError:))) {
-      self.ta_application(application, didFailToRegisterForRemoteNotificationsWithError: error)
-    }
+    AppDelegateSwizzler.callOriginalDidFail(
+      self,
+      #selector(UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:)),
+      application,
+      error
+    )
   }
 
-  // Background/remote (silent) payloads
   @objc func ta_application(_ application: UIApplication,
                             didReceiveRemoteNotification userInfo: [AnyHashable : Any],
                             fetchCompletionHandler completion: @escaping (UIBackgroundFetchResult) -> Void) {
-    // Emit event for push message
     if let jsData = JSTypes.coerceDictionaryToJSObject(userInfo) {
       try? AppDelegateSwizzler.plugin?.trigger("push-message", data: jsData)
     }
-
-    // Call original only if it was swapped (not added)
-    if responds(to: #selector(ta_application(_:didReceiveRemoteNotification:fetchCompletionHandler:))) {
-      self.ta_application(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completion)
-    } else {
-      // If no original implementation, we should still call the completion handler
+    let chained = AppDelegateSwizzler.callOriginalDidReceive(
+      self,
+      #selector(UIApplicationDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:)),
+      application,
+      userInfo,
+      completion
+    )
+    if !chained {
       completion(.noData)
     }
   }

--- a/ios/Sources/Notification.swift
+++ b/ios/Sources/Notification.swift
@@ -94,6 +94,11 @@ func makeAttachments(_ attachments: [NotificationAttachment]) throws -> [UNNotif
 }
 
 func makeAttachmentUrl(_ path: String) -> URL? {
+  // UNNotificationAttachment needs a file URL, and URL(string:) leaves an
+  // absolute filesystem path schemeless. Relative/empty input stays nil.
+  if path.hasPrefix("/") {
+    return URL(fileURLWithPath: path)
+  }
   return URL(string: path)
 }
 

--- a/ios/Sources/NotificationCategory.swift
+++ b/ios/Sources/NotificationCategory.swift
@@ -62,32 +62,32 @@ func makeActions(_ actions: [Action]) -> [UNNotificationAction] {
 }
 
 func makeActionOptions(_ action: Action) -> UNNotificationActionOptions {
+  var options: UNNotificationActionOptions = []
   if action.foreground ?? false {
-    return .foreground
+    options.insert(.foreground)
   }
   if action.destructive ?? false {
-    return .destructive
+    options.insert(.destructive)
   }
   if action.requiresAuthentication ?? false {
-    return .authenticationRequired
+    options.insert(.authenticationRequired)
   }
-  return UNNotificationActionOptions(rawValue: 0)
+  return options
 }
 
 func makeCategoryOptions(_ type: ActionType) -> UNNotificationCategoryOptions {
+  var options: UNNotificationCategoryOptions = []
   if type.customDismissAction ?? false {
-    return .customDismissAction
+    options.insert(.customDismissAction)
   }
   if type.allowInCarPlay ?? false {
-    return .allowInCarPlay
+    options.insert(.allowInCarPlay)
   }
-
   if type.hiddenPreviewsShowTitle ?? false {
-    return .hiddenPreviewsShowTitle
+    options.insert(.hiddenPreviewsShowTitle)
   }
   if type.hiddenPreviewsShowSubtitle ?? false {
-    return .hiddenPreviewsShowSubtitle
+    options.insert(.hiddenPreviewsShowSubtitle)
   }
-
-  return UNNotificationCategoryOptions(rawValue: 0)
+  return options
 }

--- a/ios/Sources/NotificationHandler.swift
+++ b/ios/Sources/NotificationHandler.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Tauri
 import UserNotifications
 
@@ -8,18 +9,48 @@ public class NotificationHandler: NSObject, NotificationHandlerProtocol {
   private var notificationsMap = [String: Notification]()
   private var hasClickedListener = false
   private var pendingNotificationClick: NotificationClickedData? = nil
+  private var hasActionListener = false
+  private var pendingNotificationActions = [ReceivedNotification]()
+  private let maxPendingActions = 32
+  // Serializes delegate callbacks and plugin commands.
+  private let stateLock = NSRecursiveLock()
 
   internal func saveNotification(_ key: String, _ notification: Notification) {
+    stateLock.lock()
+    defer { stateLock.unlock() }
     notificationsMap.updateValue(notification, forKey: key)
   }
 
   func setClickListenerActive(_ active: Bool) {
+    stateLock.lock()
     hasClickedListener = active
+    let pending = active ? pendingNotificationClick : nil
+    if pending != nil { pendingNotificationClick = nil }
+    stateLock.unlock()
+    if let pending { try? self.plugin?.trigger("notificationClicked", data: pending) }
+  }
 
-    if active, let pending = pendingNotificationClick {
-      pendingNotificationClick = nil
-      try? self.plugin?.trigger("notificationClicked", data: pending)
+  func setActionListenerActive(_ active: Bool) {
+    stateLock.lock()
+    hasActionListener = active
+    let pendingActions = active ? pendingNotificationActions : []
+    if active { pendingNotificationActions.removeAll() }
+    stateLock.unlock()
+    guard active else { return }
+    for action in pendingActions {
+      try? self.plugin?.trigger("actionPerformed", data: action)
     }
+  }
+
+  private func triggerActionPerformed(_ action: ReceivedNotification) {
+    stateLock.lock()
+    let shouldTrigger = hasActionListener
+    if !shouldTrigger && pendingNotificationActions.count >= maxPendingActions {
+      pendingNotificationActions.removeFirst()
+    }
+    if !shouldTrigger { pendingNotificationActions.append(action) }
+    stateLock.unlock()
+    if shouldTrigger { try? self.plugin?.trigger("actionPerformed", data: action) }
   }
 
   public func requestPermissions(with completion: ((Bool, Error?) -> Void)? = nil) {
@@ -37,63 +68,48 @@ public class NotificationHandler: NSObject, NotificationHandlerProtocol {
   }
 
   public func willPresent(notification: UNNotification) -> UNNotificationPresentationOptions {
+    stateLock.lock()
+    var event: (String, Encodable)? = nil
     // Trigger notification event for both local and push notifications
     if var notificationData = toActiveNotification(notification.request) {
       notificationData.source = "local"
-      try? self.plugin?.trigger("notification", data: notificationData)
+      event = ("notification", notificationData)
     } else {
       var notificationData = toReceivedNotification(notification.request)
       notificationData.source = "push"
-      try? self.plugin?.trigger("notification", data: notificationData)
+      event = ("notification", notificationData)
     }
 
     // For push notifications in foreground, don't show system notification
     // (only trigger event so developer can handle it)
     let isPushNotification = notification.request.trigger?.isKind(of: UNPushNotificationTrigger.self) == true
+    let options: UNNotificationPresentationOptions
     if isPushNotification {
-      return UNNotificationPresentationOptions.init(rawValue: 0)
+      options = UNNotificationPresentationOptions(rawValue: 0)
+    } else if let local = notificationsMap[notification.request.identifier], local.silent ?? false {
+      options = UNNotificationPresentationOptions(rawValue: 0)
+    } else {
+      options = [.badge, .sound, .alert]
     }
-
-    // For local notifications, check if silent
-    if let options = notificationsMap[notification.request.identifier] {
-      if options.silent ?? false {
-        return UNNotificationPresentationOptions.init(rawValue: 0)
-      }
-    }
-
-    return [
-      .badge,
-      .sound,
-      .alert,
-    ]
+    stateLock.unlock()
+    if let event { try? self.plugin?.trigger(event.0, data: event.1) }
+    return options
   }
 
   /// Convert notification request to ReceivedNotification (for push notifications not in map)
   private func toReceivedNotification(_ request: UNNotificationRequest) -> ReceivedNotificationData {
     let content = request.content
-    var extra: [String: String]? = nil
-
-    if !content.userInfo.isEmpty {
-      extra = [:]
-      for (key, value) in content.userInfo {
-        if let keyStr = key as? String, let valStr = value as? String {
-          extra?[keyStr] = valStr
-        }
-      }
-      if extra?.isEmpty == true {
-        extra = nil
-      }
-    }
 
     return ReceivedNotificationData(
       id: Int(request.identifier) ?? -1,
       title: content.title,
       body: content.body,
-      extra: extra
+      extra: notificationExtra(content.userInfo)
     )
   }
 
   public func didReceive(response: UNNotificationResponse) {
+    stateLock.lock()
     let originalNotificationRequest = response.notification.request
     let actionId = response.actionIdentifier
 
@@ -113,45 +129,50 @@ public class NotificationHandler: NSObject, NotificationHandlerProtocol {
       inputValue = inputType.userText
     }
 
-    // Only trigger actionPerformed for local notifications (those in our map)
-    if let activeNotification = toActiveNotification(originalNotificationRequest) {
-      try? self.plugin?.trigger(
-        "actionPerformed",
-        data: ReceivedNotification(
-          actionId: actionIdValue,
-          inputValue: inputValue,
-          notification: activeNotification
-        ))
+    let isSystemAction = actionId == UNNotificationDefaultActionIdentifier
+      || actionId == UNNotificationDismissActionIdentifier
+
+    let actionNotification = toActiveNotification(originalNotificationRequest)
+      ?? toRemoteActionNotification(originalNotificationRequest)
+    let action = ReceivedNotification(
+      actionId: actionIdValue,
+      inputValue: inputValue,
+      notification: actionNotification
+    )
+    let shouldTriggerAction = hasActionListener
+    if !shouldTriggerAction {
+      if pendingNotificationActions.count >= maxPendingActions { pendingNotificationActions.removeFirst() }
+      pendingNotificationActions.append(action)
+    }
+
+    if !isSystemAction {
+      stateLock.unlock()
+      if shouldTriggerAction { try? self.plugin?.trigger("actionPerformed", data: action) }
+      return
     }
 
     // Handle notificationClicked for both local and push notifications
     let id = Int(originalNotificationRequest.identifier) ?? -1
-    let userInfo = originalNotificationRequest.content.userInfo
-    var dataDict: [String: String]? = nil
-    if !userInfo.isEmpty {
-      dataDict = [:]
-      for (key, value) in userInfo {
-        if let keyStr = key as? String, let valStr = value as? String {
-          dataDict?[keyStr] = valStr
-        }
-      }
-      if dataDict?.isEmpty == true {
-        dataDict = nil
-      }
-    }
+    let clickedData = NotificationClickedData(
+      id: id,
+      data: notificationExtra(originalNotificationRequest.content.userInfo)
+    )
 
-    let clickedData = NotificationClickedData(id: id, data: dataDict)
-
-    if hasClickedListener {
-      // Listener exists, trigger directly
-      try? self.plugin?.trigger("notificationClicked", data: clickedData)
+    let shouldTriggerClick = hasClickedListener
+    if shouldTriggerClick {
+      // Listener exists, trigger directly after releasing the lock.
     } else {
       // No listener (cold-start), store for later
       pendingNotificationClick = clickedData
     }
+    stateLock.unlock()
+    if shouldTriggerAction { try? self.plugin?.trigger("actionPerformed", data: action) }
+    if shouldTriggerClick { try? self.plugin?.trigger("notificationClicked", data: clickedData) }
   }
 
   func toActiveNotification(_ request: UNNotificationRequest) -> ActiveNotification? {
+    stateLock.lock()
+    defer { stateLock.unlock() }
     guard let notificationRequest = notificationsMap[request.identifier] else {
       return nil
     }
@@ -161,11 +182,41 @@ public class NotificationHandler: NSObject, NotificationHandlerProtocol {
       body: request.content.body,
       sound: notificationRequest.sound ?? "",
       actionTypeId: request.content.categoryIdentifier,
-      attachments: notificationRequest.attachments
+      attachments: notificationRequest.attachments,
+      extra: notificationExtra(request.content.userInfo)
     )
   }
 
+  func toRemoteActionNotification(_ request: UNNotificationRequest) -> ActiveNotification {
+    ActiveNotification(
+      id: Int(request.identifier) ?? -1,
+      title: request.content.title,
+      body: request.content.body,
+      sound: "",
+      actionTypeId: request.content.categoryIdentifier,
+      attachments: nil,
+      extra: notificationExtra(request.content.userInfo),
+      source: "push"
+    )
+  }
+
+  private func notificationExtra(_ userInfo: [AnyHashable: Any]) -> [String: String]? {
+    var extra = [String: String]()
+    for (key, value) in userInfo {
+      guard let key = key as? String else { continue }
+      guard key != "aps" else { continue }
+      if let value = value as? String {
+        extra[key] = value
+      } else if let value = value as? NSNumber {
+        extra[key] = value.stringValue
+      }
+    }
+    return extra.isEmpty ? nil : extra
+  }
+
   func toPendingNotification(_ request: UNNotificationRequest) -> PendingNotification? {
+    stateLock.lock()
+    defer { stateLock.unlock() }
     guard let notification = notificationsMap[request.identifier],
           let schedule = notification.schedule else {
       return nil
@@ -193,7 +244,28 @@ struct ActiveNotification: Encodable {
   let sound: String
   let actionTypeId: String
   let attachments: [NotificationAttachment]?
-  var source: String = "local"
+  let extra: [String: String]?
+  var source: String
+
+  init(
+    id: Int,
+    title: String,
+    body: String,
+    sound: String,
+    actionTypeId: String,
+    attachments: [NotificationAttachment]?,
+    extra: [String: String]? = nil,
+    source: String = "local"
+  ) {
+    self.id = id
+    self.title = title
+    self.body = body
+    self.sound = sound
+    self.actionTypeId = actionTypeId
+    self.attachments = attachments
+    self.extra = extra
+    self.source = source
+  }
 }
 
 struct ReceivedNotification: Encodable {
@@ -205,6 +277,11 @@ struct ReceivedNotification: Encodable {
 struct NotificationClickedData: Encodable {
   let id: Int
   let data: [String: String]?
+
+  init(id: Int, data: [String: String]?) {
+    self.id = id
+    self.data = data
+  }
 }
 
 struct ReceivedNotificationData: Encodable {

--- a/ios/Sources/NotificationPlugin.swift
+++ b/ios/Sources/NotificationPlugin.swift
@@ -153,6 +153,14 @@ struct SetClickListenerActiveArgs: Decodable {
   let active: Bool
 }
 
+struct SetActionListenerActiveArgs: Decodable {
+  let active: Bool
+}
+
+struct PluginConfig: Decodable {
+  let actionTypes: [ActionType]?
+}
+
 class NotificationPlugin: Plugin {
   let notificationHandler = NotificationHandler()
   let notificationManager = NotificationManager()
@@ -172,6 +180,11 @@ class NotificationPlugin: Plugin {
 
   public override func load(webview: WKWebView) {
     super.load(webview: webview)
+
+    if let config = try? parseConfig(PluginConfig.self),
+       let actionTypes = config.actionTypes {
+      makeCategories(actionTypes)
+    }
 
     #if ENABLE_PUSH_NOTIFICATIONS
       // Store reference to this plugin for event triggering
@@ -252,18 +265,19 @@ class NotificationPlugin: Plugin {
   #if ENABLE_PUSH_NOTIFICATIONS
     private func registerForPushNotifications(completion: @escaping (Result<String, Error>) -> Void)
     {
-      // Store completion for later
-      self.pushTokenCompletion = completion
+      // Main queue: the caller runs on an arbitrary thread whose run loop never
+      // runs (so the Timer would never fire), and this serializes the token state.
+      DispatchQueue.main.async { [weak self] in
+        guard let self = self else { return }
+        self.pushTokenCompletion = completion
 
-      // Set up timeout
-      self.pushTokenTimer?.invalidate()
-      self.pushTokenTimer = Timer.scheduledTimer(withTimeInterval: pushTokenTimeout, repeats: false)
-      { [weak self] _ in
-        self?.handlePushTokenTimeout()
-      }
+        self.pushTokenTimer?.invalidate()
+        self.pushTokenTimer = Timer.scheduledTimer(
+          withTimeInterval: self.pushTokenTimeout, repeats: false
+        ) { [weak self] _ in
+          self?.handlePushTokenTimeout()
+        }
 
-      // Register for remote notifications
-      DispatchQueue.main.async {
         UIApplication.shared.registerForRemoteNotifications()
       }
     }
@@ -385,6 +399,16 @@ class NotificationPlugin: Plugin {
     do {
       let args = try invoke.parseArgs(SetClickListenerActiveArgs.self)
       notificationHandler.setClickListenerActive(args.active)
+      invoke.resolve()
+    } catch {
+      invoke.reject(error.localizedDescription)
+    }
+  }
+
+  @objc func setActionListenerActive(_ invoke: Invoke) {
+    do {
+      let args = try invoke.parseArgs(SetActionListenerActiveArgs.self)
+      notificationHandler.setActionListenerActive(args.active)
       invoke.resolve()
     } catch {
       invoke.reject(error.localizedDescription)

--- a/ios/Tests/PluginTests/PluginTests.swift
+++ b/ios/Tests/PluginTests/PluginTests.swift
@@ -4,6 +4,17 @@ import UserNotifications
 
 final class NotificationTests: XCTestCase {
 
+    func testPluginConfigDecodesLaunchTimeActionTypes() throws {
+        let json = """
+        {"actionTypes":[{"id":"sable-message","actions":[{"id":"sable-reply","title":"Reply","input":true,"inputButtonTitle":"Send","inputPlaceholder":"Type a reply"}]}]}
+        """
+        let config = try JSONDecoder().decode(PluginConfig.self, from: Data(json.utf8))
+
+        XCTAssertEqual(config.actionTypes?.first?.id, "sable-message")
+        XCTAssertEqual(config.actionTypes?.first?.actions.first?.id, "sable-reply")
+        XCTAssertEqual(config.actionTypes?.first?.actions.first?.input, true)
+    }
+
     // MARK: - Notification Content Tests
 
     func testMakeNotificationContentWithBasicNotification() throws {
@@ -540,6 +551,64 @@ final class NotificationTests: XCTestCase {
         XCTAssertEqual(json?["source"] as? String, "local")
     }
 
+    func testActiveNotificationIncludesExtraMetadata() throws {
+        let handler = NotificationHandler()
+        let notification = Notification(
+            id: 42,
+            title: "Message",
+            body: "Reply",
+            extra: ["room_id": "!room:example.org", "event_id": "$event"],
+            schedule: nil,
+            attachments: nil,
+            sound: nil,
+            group: nil,
+            actionTypeId: "message-actions",
+            summary: nil,
+            silent: nil
+        )
+        handler.saveNotification("42", notification)
+
+        let content = try makeNotificationContent(notification)
+        let request = UNNotificationRequest(identifier: "42", content: content, trigger: nil)
+        let active = handler.toActiveNotification(request)
+
+        XCTAssertEqual(active?.actionTypeId, "message-actions")
+        XCTAssertEqual(active?.extra?["room_id"], "!room:example.org")
+        XCTAssertEqual(active?.extra?["event_id"], "$event")
+    }
+
+    func testRemoteActionNotificationIncludesRoutingMetadata() throws {
+        let handler = NotificationHandler()
+        let content = UNMutableNotificationContent()
+        content.title = "New message"
+        content.body = "Reply inline"
+        content.categoryIdentifier = "sable-message"
+        content.userInfo = [
+            "room_id": "!room:example.org",
+            "event_id": "$event",
+            "user_id": "@user:example.org",
+        ]
+        let request = UNNotificationRequest(identifier: "remote-message", content: content, trigger: nil)
+
+        let active = handler.toRemoteActionNotification(request)
+        let result = ReceivedNotification(
+            actionId: "reply",
+            inputValue: "Hello",
+            notification: active
+        )
+        let data = try JSONEncoder().encode(result)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let notification = json?["notification"] as? [String: Any]
+        let extra = notification?["extra"] as? [String: String]
+
+        XCTAssertEqual(active.id, -1)
+        XCTAssertEqual(active.source, "push")
+        XCTAssertEqual(active.actionTypeId, "sable-message")
+        XCTAssertEqual(extra?["room_id"], "!room:example.org")
+        XCTAssertEqual(extra?["event_id"], "$event")
+        XCTAssertEqual(extra?["user_id"], "@user:example.org")
+    }
+
     func testReceivedNotificationEncoding() throws {
         let active = ActiveNotification(
             id: 1,
@@ -547,7 +616,8 @@ final class NotificationTests: XCTestCase {
             body: "Body",
             sound: "default",
             actionTypeId: "CATEGORY",
-            attachments: nil
+            attachments: nil,
+            extra: ["room_id": "!room:example.org"]
         )
 
         let received = ReceivedNotification(
@@ -570,6 +640,10 @@ final class NotificationTests: XCTestCase {
         let notification = json?["notification"] as? [String: Any]
         XCTAssertNotNil(notification)
         XCTAssertEqual(notification?["id"] as? Int, 1)
+        XCTAssertEqual(
+            (notification?["extra"] as? [String: String])?["room_id"],
+            "!room:example.org"
+        )
     }
 
     // MARK: - NotificationHandler Tests
@@ -721,8 +795,8 @@ final class NotificationTests: XCTestCase {
 
         let options = makeActionOptions(action)
 
-        // Should return foreground as it's checked first
-        XCTAssertEqual(options, .foreground)
+        // Options form an OptionSet, so every requested flag is combined
+        XCTAssertEqual(options, [.foreground, .destructive, .authenticationRequired])
     }
 
     func testMakeCategoryOptionsWithMultipleFlags() {
@@ -739,8 +813,11 @@ final class NotificationTests: XCTestCase {
 
         let options = makeCategoryOptions(actionType)
 
-        // Should return customDismissAction as it's checked first
-        XCTAssertEqual(options, .customDismissAction)
+        // Options form an OptionSet, so every requested flag is combined
+        XCTAssertEqual(
+            options,
+            [.customDismissAction, .allowInCarPlay, .hiddenPreviewsShowTitle, .hiddenPreviewsShowSubtitle]
+        )
     }
 
     // MARK: - Silent Notification Tests


### PR DESCRIPTION
- AppDelegateSwizzler: chain existing push delegate callbacks instead of replacing them
- NotificationHandler: queue action results until JS is ready via setActionListenerActive, make categories from config.actionTypes so provider-rendered notifications with an aps.category are handled before JavaScript initializes
- NotificationPlugin: wire setActionListenerActive to the handler
- NotificationCategory: build UNNotificationCategory from ActionType
- registration: enforce a timeout so a hung APNs registration rejects instead of hanging
- tests: cover config.actionTypes decoding, extra metadata, remote action routing