### PR TITLE
Cancel superseded CI runs per ref

### DIFF
--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -3,7 +3,7 @@ name: Build Demo
 on:
   pull_request:
   push:
-    branches: ['**']
+    branches: [main]
 
 concurrency:
   # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes

--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: ['**']
 
+concurrency:
+  # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes
+  # alike); main is pinned to a unique group (run_id) so every commit on main
+  # gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # Build the example app on every desktop OS. Catches platform-specific
   # regressions.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: ['**']
 
+concurrency:
+  # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes
+  # alike); main is pinned to a unique group (run_id) so every commit on main
+  # gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   # Code formatting.
   fmt:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Checks
 on:
   pull_request:
   push:
-    branches: ['**']
+    branches: [main]
 
 concurrency:
   # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes
+  # alike); main is pinned to a unique group (run_id) so every commit on main
+  # gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test-rust:
     name: Rust Tests


### PR DESCRIPTION
Two CI-economy changes:

**1. Superseded runs cancel.** A `concurrency` group per workflow + ref (pull-request merge refs and branch pushes alike) with `cancel-in-progress`, so only the newest head's run survives per series. `main` is pinned to a unique group per run: every commit on main keeps its own full, uncancellable verification run.

**2. Push CI runs on main only.** `build-demo.yml` and `checks.yml` ran on `push: branches: ['**']`, so every PR push triggered two full matrices — the pull_request run plus a duplicate branch-push run. Narrowed to `[main]`; `tests.yml` already was. PRs keep their pull_request runs.

`publish.yml` (tag-triggered, own concurrency) is untouched.
