### PR TITLE
Publish on Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
           cache: "pnpm"
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       # Install dependencies
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       # Node + registry auth
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: '24'
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 


### PR DESCRIPTION
The publish workflow pins Node 20, which is past end-of-life — its `npm install -g npm@latest` step now fails because npm 12 requires Node ≥22.22. Pin moves to Node 24 (active LTS), matching the other repos' publish workflows.