### PR TITLE
[ci-experiment] [ci-experiment] Kotlin Android plugin pin 2.4.10

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -11,7 +11,7 @@ pluginManagement {
                     useVersion("8.13.1")
                     break
                 case "org.jetbrains.kotlin.android":
-                    useVersion("2.2.21")
+                    useVersion("2.4.10")
                     break
             }
         }


### PR DESCRIPTION
[ci-experiment] Discardable draft — verifying that raising the org.jetbrains.kotlin.android pin in android/settings.gradle to 2.4.10 lets the standalone android build compile against kotlin-test 2.4 metadata. Will be closed once CI answers; not for merge.

---
CI experiment: opened only to run the workflows on this branch; closed once the result is in, never merged.